### PR TITLE
Put a box around the survey question text when editing a question

### DIFF
--- a/app/javascript/constants/strings.js
+++ b/app/javascript/constants/strings.js
@@ -87,6 +87,8 @@ module.exports = {
     QUESTION_DUPLICATE_ERROR: errorMessage("Question failed to be duplicated."),
     QUESTION_ADD_SAVE_SUCCESS: "Question successfully added",
     QUESTION_ADD_SAVE_ERROR: errorMessage("Question failed to be added."),
+    QUESTION_UNCHANGED: "Question change abandoned",
+    QUESTION_MODAL_MESSAGE: "You are changing the question type and there's a linked field associated with that specific question type. If you continue with changing the question type, we will remove the linked field. You can choose to leave the question type as it is and the linking will remain.",
 
     //answer actions
     ANSWER_ORDER_SAVE_SUCCESS: "Answer reorder sucessfully saved",

--- a/app/javascript/surveys/edit-survey-question.vue
+++ b/app/javascript/surveys/edit-survey-question.vue
@@ -137,6 +137,12 @@
         <b-button variant="info" @click="deleteSelectedQuestion"><b-icon-trash></b-icon-trash></b-button>
       </div>
     </div>
+    <b-modal id='unlink-question-modal' size="lg"
+             hide-header-close no-close-on-backdrop no-close-on-esc
+             title="Really??" @cancel="unlinkQuestion" @ok="restoreOldValues"
+             cancel-title="Yes, unlink" ok-title="Leave question type as it was">
+      <div>{{QUESTION_MODAL_MESSAGE}}</div>
+    </b-modal>
   </div>
 </template>
 
@@ -150,7 +156,7 @@ import {
   pageMixin,
   questionMixin
 } from '@mixins';
-import { LINKED_FIELD_LABELS, SURVEY_YESNOMAYBE_PLACEHOLDER } from '@/constants/strings';
+import { LINKED_FIELD_LABELS, SURVEY_YESNOMAYBE_PLACEHOLDER, QUESTION_MODAL_MESSAGE } from '@/constants/strings';
 
 
 export default {
@@ -162,7 +168,8 @@ export default {
     LinkedField,
   },
   data: () => ({
-    SURVEY_YESNOMAYBE_PLACEHOLDER
+    SURVEY_YESNOMAYBE_PLACEHOLDER,
+    QUESTION_MODAL_MESSAGE
   }),
   props: {
     question: {

--- a/app/javascript/surveys/edit-survey-question.vue
+++ b/app/javascript/surveys/edit-survey-question.vue
@@ -9,7 +9,7 @@
          :label-for="formId('question-text')"
         >
 
-          <plano-editor
+          <plano-editor style="border: solid 2px; border-radius: 5px;"
             :id="formId('question-text')"
             v-model="question.question"
             @blur="patchSelectedQuestion({question: $event.editor._.data})"

--- a/app/javascript/surveys/question.mixin.js
+++ b/app/javascript/surveys/question.mixin.js
@@ -13,6 +13,7 @@ import {
   QUESTION_SAVE_SUCCESS
 } from '../constants/strings'
 import settingsMixin from '@/store/settings.mixin';
+import {QUESTION_UNCHANGED} from "@/constants/strings";
 
 // CONVERTED
 export const questionMixin = {
@@ -34,6 +35,9 @@ export const questionMixin = {
       { value: 'yesnomaybe', text: 'Yes/No/Maybe' },
       { value: 'boolean', text: 'Boolean (Yes/No)' }
     ],
+    saved_question: null,
+    saved_question_data: null,
+    saved_question_message: null
   }),
   computed: {
     ...mapGetters({
@@ -165,13 +169,40 @@ export const questionMixin = {
       return this.fetchSurveyToastPromise( this.delete({model, itemOrId: this.selectedQuestion}), QUESTION_DELETE_SUCCESS, QUESTION_DELETE_ERROR);
     },
     patchQuestion(question, data, message = QUESTION_SAVE_SUCCESS) {
-      return this.toastPromise(this.$store.dispatch('jv/patch', { ...data, _jv: {
-        id: question.id,
-        type: model
-      }}), message)
+      if(data.question_type && question.linked_field) {
+        // alert("question="+JSON.stringify(question));
+        // alert("linked_field="+question.linked_field);
+        // alert("data=" + JSON.stringify(data));
+        this.saved_question=question;
+        this.saved_question_data=data;
+        this.saved_question_message=message;
+        this.$root.$emit('bv::show::modal', 'unlink-question-modal' )
+      } else {
+        return this.toastPromise(this.$store.dispatch('jv/patch', {
+          ...data, _jv: {
+            id: question.id,
+            type: model
+          }
+        }), message)
+      }
     },
     patchSelectedQuestion(data, message = QUESTION_SAVE_SUCCESS) {
       return this.patchQuestion(this.selectedQuestion, data, message)
+    },
+    unlinkQuestion() {
+      // alert("unlinking!!");
+      this.saved_question_data.linked_field=null;
+      delete(this.saved_question.linked_field);
+      return this.toastPromise(this.$store.dispatch('jv/patch', {
+        ...this.saved_question_data, _jv: {
+          id: this.saved_question.id,
+          type: model
+        }
+      }), this.saved_question_message)
+    },
+    restoreOldValues() {
+      //alert("throwing away the attempt to change the question type");
+      this.success_toast(QUESTION_UNCHANGED);
     }
   }
 }


### PR DESCRIPTION
When you actually select the question, the box appears to move a tiny bit, but it's much better than the double box I had earlier