### PR TITLE
PLAN-310 hide admin tab like in the flyout

### DIFF
--- a/app/javascript/people/person_tabs.vue
+++ b/app/javascript/people/person_tabs.vue
@@ -41,7 +41,7 @@
             :person_id="person.id"
           ></session-ranker>
         </b-tab>
-        <b-tab title="Admin" disabled lazy>
+        <b-tab title="Admin" disabled lazy v-if="currentUserIsAdmin">
         </b-tab>
         <b-tab title="Surveys" disabled lazy>
         </b-tab>


### PR DESCRIPTION
- only people who can see the admin page can see the admin tab.
(not that there is anything on it yet)