### PR TITLE
PLAN-324 disallow editing sensitive data

### DIFF
--- a/app/javascript/profile/person_demographics.vue
+++ b/app/javascript/profile/person_demographics.vue
@@ -2,13 +2,11 @@
   <section>
     <div class="d-flex flex-row mt-3">
       <div class="w-50 mr-2">
-        <!-- TODO change edit permissions to sensitive data tickybox -->
-        <h5>Demographics <edit-button v-b-modal.person-demo-modal v-if="currentUserIsAdmin"></edit-button></h5>
+        <h5>Demographics <edit-button v-b-modal.person-demo-modal v-if="canEditInfo"></edit-button></h5>
         <dl-person :fields="demoFields"></dl-person>
       </div>
       <div class="w-50">
-        <!-- TODO change edit permissions to sensitive data tickybox -->
-        <h5>Community memberships <edit-button v-b-modal.person-community-modal v-if="currentUserIsAdmin"></edit-button></h5>
+        <h5>Community memberships <edit-button v-b-modal.person-community-modal v-if="canEditInfo"></edit-button></h5>
         <dl-person :fields="communityFields"></dl-person>
       </div>
     </div>
@@ -94,6 +92,10 @@ export default {
     },
     communityFields() {
       return Object.keys(this.communityData);
+    },
+    canEditInfo() {
+      // TODO use sensitive data permission in the future
+      return this.currentUserIsAdmin || this.currentUser.id === this.selected.id;
     }
   }
 };

--- a/app/javascript/profile/person_demographics.vue
+++ b/app/javascript/profile/person_demographics.vue
@@ -2,42 +2,14 @@
   <section>
     <div class="d-flex flex-row mt-3">
       <div class="w-50 mr-2">
-        <h5>Demographics <edit-button v-b-modal.person-demo-modal></edit-button></h5>
+        <!-- TODO change edit permissions to sensitive data tickybox -->
+        <h5>Demographics <edit-button v-b-modal.person-demo-modal v-if="currentUserIsAdmin"></edit-button></h5>
         <dl-person :fields="demoFields"></dl-person>
-        <!-- <dl>
-          <dt>Ethnicity</dt>
-          <dd class="ml-2">{{ selected.ethnicity | na_if_empty }}</dd>
-          <dt>Gender</dt>
-          <dd class="ml-2">{{ selected.gender | na_if_empty }}</dd>
-          <dt>Age at time of event</dt>
-          <dd class="ml-2">{{ selected.age_at_convention | na_if_empty }}</dd>
-          <dt>Romantic and/or sexual orientation</dt>
-          <dd class="ml-2">
-            {{ selected.romantic_sexual_orientation | na_if_empty }}
-          </dd>
-        </dl> -->
       </div>
       <div class="w-50">
-        <h5>Community memberships <edit-button v-b-modal.person-community-modal></edit-button></h5>
+        <!-- TODO change edit permissions to sensitive data tickybox -->
+        <h5>Community memberships <edit-button v-b-modal.person-community-modal v-if="currentUserIsAdmin"></edit-button></h5>
         <dl-person :fields="communityFields"></dl-person>
-        <!-- <dl>
-          <dt>Experience with being “othered”</dt>
-          <dd class="ml-2">{{ selected.othered | na_if_empty }}</dd>
-          <dt>Member of an Indigenous community</dt>
-          <dd class="ml-2">{{ selected.indigenous | na_if_empty }}</dd>
-          <dt>Member of the global Black diaspora</dt>
-          <dd class="ml-2">{{ selected.black_diaspora | na_if_empty }}</dd>
-          <dt>
-            Represent something other than a purely US-centric perspective
-          </dt>
-          <dd class="ml-2">
-            {{ selected.non_us_centric_perspectives | na_if_empty }}
-          </dd>
-          <dt>Other demographic categories</dt>
-          <dd class="ml-2">
-            {{ selected.demographic_categories | na_if_empty }}
-          </dd>
-        </dl> -->
       </div>
     </div>
     <person-edit-modal id="person-demo-modal" :person="selected" :data="demoData">
@@ -87,6 +59,7 @@ import { personModel as model } from "@/store/person.store";
 import PersonEditModal from "./person_edit_modal.vue";
 import EditButton from '@/components/edit_button';
 import DlPerson from './dl_person.vue';
+import personSessionMixin from '@/auth/person_session.mixin';
 
 export default {
   name: "PersonDemographics",
@@ -112,7 +85,8 @@ export default {
     }
   }),
   mixins: [
-    modelMixinNoProp
+    modelMixinNoProp,
+    personSessionMixin
   ],
   computed: {
     demoFields() {

--- a/app/javascript/profile/person_details.vue
+++ b/app/javascript/profile/person_details.vue
@@ -65,8 +65,11 @@
       <template #modal-title>Edit Preferences - {{selected.published_name}}</template>
       <template #default="{fields}">
         <b-form-group label="Anyone that should not be assigned to be on a panel with participant">
-          <b-form-textarea v-model="fields.do_not_assign_with"></b-form-textarea>
+          <!-- TODO change edit permissions to sensitive data tickybox -->
+          <b-form-textarea v-if="currentUserIsAdmin" v-model="fields.do_not_assign_with"></b-form-textarea>
+          <b-form-textarea v-if="!currentUserIsAdmin" disabled value="Restricted"></b-form-textarea>
         </b-form-group>
+
         <b-form-group label="Permission to be included in a livestreamed program">
             <b-form-radio-group
               stacked
@@ -204,6 +207,7 @@ import settingsMixin from "@/store/settings.mixin";
 import { modelMixinNoProp } from '@/store/model.mixin';
 import { personModel as model } from "@/store/person.store";
 import { DateTime } from "luxon";
+import personSessionMixin from '@/auth/person_session.mixin';
 
 export default {
   name: "PersonDetails",
@@ -219,7 +223,8 @@ export default {
   },
   mixins: [
     settingsMixin,
-    modelMixinNoProp
+    modelMixinNoProp,
+    personSessionMixin
   ],
   data: () =>  ({
     disabled: false,

--- a/app/javascript/profile/person_details.vue
+++ b/app/javascript/profile/person_details.vue
@@ -66,8 +66,8 @@
       <template #default="{fields}">
         <b-form-group label="Anyone that should not be assigned to be on a panel with participant">
           <!-- TODO change edit permissions to sensitive data tickybox -->
-          <b-form-textarea v-if="currentUserIsAdmin" v-model="fields.do_not_assign_with"></b-form-textarea>
-          <b-form-textarea v-if="!currentUserIsAdmin" disabled value="Restricted"></b-form-textarea>
+          <b-form-textarea v-if="canEditSensitiveInfo" v-model="fields.do_not_assign_with"></b-form-textarea>
+          <b-form-textarea v-if="!canEditSensitiveInfo" disabled value="Restricted"></b-form-textarea>
         </b-form-group>
 
         <b-form-group label="Permission to be included in a livestreamed program">
@@ -313,6 +313,10 @@ export default {
         label: "Yes, except for items focused on the topics listed below.",
         value: "maybe"};
     },
+    canEditSensitiveInfo() {
+      // TODO in the future use the sensitive data permission instead of the admin setting
+      return this.currentUserIsAdmin || this.currentUser.id === this.selected.id;
+    }
   },
 }
 </script>


### PR DESCRIPTION
- you can see and edit your own restricted data
- you cannot see and edit the restricted data of others unless you are an admin
- in the future, this should use the sensitive data permission bit instead of admin perms