### PR TITLE
PLAN-321 fix 422 error handling

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -37,10 +37,14 @@ import { CustomIconsPlugin } from '../icons';
 import AsyncComputed from 'vue-async-computed';
 import CKEditor from 'ckeditor4-vue';
 import VuePluralize from 'vue-pluralize';
+
 Vue.config.errorHandler = (err, vm, info) => {
   console.error(err);
-  window.alert("Whoops! We messed up! Click ok to reload the page.")
-  window.location.reload();
+  // set up in webpack
+  if(NODE_ENV !== 'development' || (err?.response && err.response?.status !== 422)) {
+    window.alert("Whoops! We messed up! Click ok to reload the page.")
+    window.location.reload();
+  }
 }
 
 Vue.use(BootstrapVue);

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -11,6 +11,12 @@ environment.loaders.prepend('erb', erb)
 
 var path = require('path');
 
+environment.plugins.prepend('env',
+  new webpack.DefinePlugin({
+    'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+  })
+)
+
 // added and allow BootstrapVue to work.
 const config = environment.toWebpackConfig()
 config.resolve = {


### PR DESCRIPTION
does not force the page to reload on a 422, instead just displays the nicely
formatted error message.

as a bonus - now NEVER displays the stupid popup in dev, only in production envs. PHEW