### PR TITLE
keep conflict when selecting another session

### DIFF
--- a/app/javascript/schedule/schedule_day.vue
+++ b/app/javascript/schedule/schedule_day.vue
@@ -185,7 +185,6 @@ export default {
       e.stopPropagation()
       if (event.split) {
         this.select(event.id)
-        this.$emit("show-conflicts", event.id);
       }
     },
     onEventDrop ({ event, originalEvent, external }) {


### PR DESCRIPTION
Do not remove the shown conflict when selecting another session

(Note: conflict will still change or disappear on dragging a session onto grid or changing time as that was the original spec)