### PR TITLE
PLAN-315 PLAN-316 PLAN-287 add fields to session flyout

### DIFF
--- a/app/javascript/components/date_time.mixin.js
+++ b/app/javascript/components/date_time.mixin.js
@@ -1,16 +1,25 @@
+import { conventionTimezoneMixin } from "@/mixins";
 
 const { DateTime } = require("luxon");
 
 export const dateTimeMixin = {
+  mixins: [
+    conventionTimezoneMixin
+  ],
   props: {
     timezone: {
       type: String,
       default: null
     }
   },
+  computed: {
+    tz() {
+      return this.timezone || this.conventionTimezone;
+    }
+  },
   methods: {
     formatLocaleDate(date) {
-      let res = DateTime.fromISO(date, {zone: this.timezone}).toLocaleString(DateTime.DATETIME_FULL)
+      let res = DateTime.fromISO(date, {zone: this.tz}).toLocaleString(DateTime.DATETIME_FULL)
       return res
     },
     // Take a Javascript datetime and format it as a time string in the local timezone
@@ -45,7 +54,7 @@ export const dateTimeMixin = {
         day: date.getDate(),
         hour: date.getHours(),
         minute: date.getMinutes()},
-        { zone: this.timezone }
+        { zone: this.tz }
       )
     }
   }

--- a/app/javascript/conflicts/session_conflicts.vue
+++ b/app/javascript/conflicts/session_conflicts.vue
@@ -36,20 +36,24 @@ export default {
   }),
   watch: {
     sessionId(newVal, oldVal) {
+      console.debug("SEssion id set")
       if (newVal) {
-        this.get_conflicts({session_id: newVal}).then(
-          (conflicts) => {
-            this.conflicts = Object.values(conflicts).filter(
-              obj => (typeof obj.json === 'undefined')
-            )
-          }
-        )
+        this.getConflicts(newVal)
       } else {
         this.conflicts = []
       }
     }
   },
   methods: {
+    getConflicts(sessionId) {
+      this.get_conflicts({session_id: sessionId}).then(
+        (conflicts) => {
+          this.conflicts = Object.values(conflicts).filter(
+            obj => (typeof obj.json === 'undefined')
+          )
+        }
+      )
+    },
     conflict_type_string(conflict_type) {
       switch (conflict_type) {
         case 'availability':
@@ -58,6 +62,11 @@ export default {
         default:
           return "a conflict"
       }
+    }
+  },
+  mounted() {
+    if (this.sessionId) {
+      this.getConflicts(this.sessionId)
     }
   }
 }

--- a/app/javascript/conflicts/session_conflicts.vue
+++ b/app/javascript/conflicts/session_conflicts.vue
@@ -1,15 +1,19 @@
 <template>
   <div class="session-conflicts">
     <div class="session-conflicts-list" v-if="conflicts.length > 0">
-      <strong>{{conflicts[0].session.title}}</strong><br />
-      {{ formatLocaleDate(conflicts[0].session.start_time )}}
-      <div
-        class="session-conflict mb-1"
-        v-for="conflict in conflicts" :key="conflict.id"
-      >
-        <div>
-          <router-link :to="'/people/availability/' + conflict.person.id">{{conflict.person.published_name}}</router-link>
-          {{conflict_type_string(conflict.conflict_type)}}
+      <div v-if="displaySessionInfo">
+        <strong>{{conflicts[0].session.title}}</strong><br />
+        {{ formatLocaleDate(conflicts[0].session.start_time )}}
+      </div>
+      <div class="ml-2">
+        <div
+          class="session-conflict mb-1"
+          v-for="conflict in conflicts" :key="conflict.id"
+        >
+          <div>
+            <router-link :to="'/people/availability/' + conflict.person.id">{{conflict.person.published_name}}</router-link>
+            {{conflict_type_string(conflict.conflict_type)}}
+          </div>
         </div>
       </div>
     </div>
@@ -20,6 +24,7 @@
 import sessionConflictMixin from '../store/session_conflict.mixin';
 import modelMixin from '../store/model.mixin';
 import dateTimeMixin from '../components/date_time.mixin'
+import { CONFLICT_TEXT } from '@/constants/strings';
 
 export default {
   name: "SessionConflicts",
@@ -29,7 +34,11 @@ export default {
     sessionConflictMixin
   ],
   props: {
-    sessionId: null
+    sessionId: null,
+    displaySessionInfo: {
+      type: Boolean,
+      default: true
+    }
   },
   data: () =>  ({
     conflicts: []
@@ -55,13 +64,7 @@ export default {
       )
     },
     conflict_type_string(conflict_type) {
-      switch (conflict_type) {
-        case 'availability':
-          return "outside of availability"
-          break;
-        default:
-          return "a conflict"
-      }
+      return CONFLICT_TEXT[conflict_type] || CONFLICT_TEXT.default;
     }
   },
   mounted() {
@@ -78,8 +81,12 @@ export default {
   max-height: 300px;
 }
 
-.session-conflict {
-  border: 1px solid rgba(0,100,150,.15);
-  padding: .2em .4em;
+.session-conflict:first-child {
+  margin-top: 1em;
 }
+
+.session-conflict:not(:first-child) {
+  border-top: 1px solid rgba(0,100,150,.15);
+}
+
 </style>

--- a/app/javascript/constants/strings.js
+++ b/app/javascript/constants/strings.js
@@ -234,5 +234,9 @@ module.exports = {
         pseudonym: "Pseudonym",
         languages_fluent_in: "Languages spoken"
     },
-    PERSON_SAVE_SUCCESS: "Profile record saved successfully"
+    PERSON_SAVE_SUCCESS: "Profile record saved successfully",
+    CONFLICT_TEXT: {
+        availability: 'is outside of availability',
+        default: 'a conflict'
+    }
 }

--- a/app/javascript/mixins.js
+++ b/app/javascript/mixins.js
@@ -12,3 +12,4 @@ export { responseMixin } from './surveys/response.mixin';
 export { authMixin } from './auth/auth.mixin';
 export { linkedMixin } from './surveys/linked.mixin';
 export { settingsMixin } from './store/settings.mixin';
+export { conventionTimezoneMixin } from './shared/convention-timezone.mixin';

--- a/app/javascript/schedule/schedule_screen.vue
+++ b/app/javascript/schedule/schedule_screen.vue
@@ -10,7 +10,6 @@
           style="flex: 1 0 auto"
         >
         </schedulable-sessions>
-        <!-- TODO - replace this -->
         <session-conflicts
           :model="sessionConflictModel"
           :sessionId="sessionIdForConflict"

--- a/app/javascript/sessions/assign_participants.vue
+++ b/app/javascript/sessions/assign_participants.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-import modelMixin from '../store/model.mixin';
+import { modelMixin } from '@/store/model.mixin';
 import modelUtilsMixin from "@/store/model_utils.mixin";
 import tableMixin from '../store/table.mixin';
 import { sessionAssignmentModel } from '@/store/session_assignment.store'
@@ -46,6 +46,7 @@ import AssignmentState from './assignment_state'
 import ParticipantSearch from './participant_search'
 import Assignee from './assignee'
 import PersonDetails from './person_details'
+import { sessionModel } from '@/store/session.store';
 
 export default {
   name: "AssignParticipants",
@@ -58,17 +59,8 @@ export default {
   mixins: [
     modelMixin,
     modelUtilsMixin,
-    tableMixin // covers pagination and sorting
+    tableMixin, // covers pagination and sorting
   ],
-  model: {
-    prop: 'session'
-  },
-  props: {
-    session: {
-      type: Object,
-      required: true
-    }
-  },
   data() {
     return {
       sessionAssignmentModel,
@@ -76,6 +68,9 @@ export default {
     }
   },
   computed: {
+    session() {
+      return this.selected_model(sessionModel);
+    },
     peopleFilter() {
       let filter = {
         "op": "all",
@@ -105,11 +100,7 @@ export default {
       )
     },
     refreshSession() {
-      this.fetch_model_by_id('session',this.session.id).then(
-        (obj) => {
-          this.$emit('input',obj)
-        }
-      )
+      this.fetch_model_by_id('session',this.session.id);
     }
   },
   mounted() {

--- a/app/javascript/sessions/session_fields.mixin.js
+++ b/app/javascript/sessions/session_fields.mixin.js
@@ -17,7 +17,8 @@ export const areaMixin = {
 export const scheduledMixin = {
   computed: {
     scheduled() {
-      return this.session ? (!!this.session.room && !!this.session.start_time && !!this.session.duration) : false;
+      const session = this.session || this.selected;
+      return session ? (!!session.room && !!session.start_time && !!session.duration) : false;
     }
   }
 }

--- a/app/javascript/sessions/session_fields.mixin.js
+++ b/app/javascript/sessions/session_fields.mixin.js
@@ -1,4 +1,4 @@
-import { settingsMixin } from '@/mixins';
+import { conventionTimezoneMixin } from '@/mixins';
 import { DateTime } from 'luxon';
 
 export const areaMixin = {
@@ -24,7 +24,7 @@ export const scheduledMixin = {
 
 export const startTimeMixin = {
   mixins: [
-    settingsMixin,
+    conventionTimezoneMixin
   ],
   computed: {
     formattedStartTime() {
@@ -32,9 +32,6 @@ export const startTimeMixin = {
         return DateTime.fromISO(this.selected.start_time, {zone: 'utc'}).setZone(this.conventionTimezone).toFormat('DDDD, t ZZZZ');
       }
       return '';
-    },
-    conventionTimezone() {
-      return this.currentSettings?.configs?.find(c => c.parameter === 'convention_timezone')?.parameter_value || 'UTC'
     },
   }
 }

--- a/app/javascript/sessions/session_fields.mixin.js
+++ b/app/javascript/sessions/session_fields.mixin.js
@@ -1,0 +1,40 @@
+import { settingsMixin } from '@/mixins';
+import { DateTime } from 'luxon';
+
+export const areaMixin = {
+  computed: {
+    formattedAreaList() {
+      return this.formatAreas(this.selected?.area_list);
+    }
+  },
+  methods: {
+    formatAreas(areas)  {
+      return areas?.length ? areas.join(", ") : '';
+    }
+  }
+}
+
+export const scheduledMixin = {
+  computed: {
+    scheduled() {
+      return this.session ? (!!this.session.room && !!this.session.start_time && !!this.session.duration) : false;
+    }
+  }
+}
+
+export const startTimeMixin = {
+  mixins: [
+    settingsMixin,
+  ],
+  computed: {
+    formattedStartTime() {
+      if(this.selected?.start_time) {
+        return DateTime.fromISO(this.selected.start_time, {zone: 'utc'}).setZone(this.conventionTimezone).toFormat('DDDD, t ZZZZ');
+      }
+      return '';
+    },
+    conventionTimezone() {
+      return this.currentSettings?.configs?.find(c => c.parameter === 'convention_timezone')?.parameter_value || 'UTC'
+    },
+  }
+}

--- a/app/javascript/sessions/session_sidebar.vue
+++ b/app/javascript/sessions/session_sidebar.vue
@@ -20,18 +20,59 @@
             </dl>
           </b-col>
         </b-row>
+        <b-row>
+          <div class="col-12 col-md-6 col-lg-4">
+            <b-form-group>
+              <b-form-checkbox v-model="selected.open_for_interest" disabled switch>
+                Open for Interest
+              </b-form-checkbox>
+            </b-form-group>
+          </div>
+          <div class="col-12 col-md-6 col-lg-4">
+            <b-form-group>
+              <b-form-checkbox switch v-model="selected.proofed" disabled>
+                Copy Edited/Proofed
+              </b-form-checkbox>
+            </b-form-group>
+          </div>
+          <div class="col-12 col-md-6 col-lg-4">
+            <b-form-group>
+              <b-form-checkbox switch disabled :checked="scheduled">
+                Scheduled
+              </b-form-checkbox>
+            </b-form-group>
+          </div>
+        </b-row>
         <div class="float-right d-flex justify-content-end">
           <b-button title="Edit Session" variant="primary" :to="editLink"><b-icon-pencil variant="white"></b-icon-pencil></b-button>
         </div>
         <b-tabs content-class="mt-3" nav-class="border-0" nav-wrapper-class="border-bottom">
           <!-- TODO: more details etc -->
           <b-tab title="General" active>
-            <b-form-checkbox v-model="selected.open_for_interest" disabled switch>
-              Open for Interest
-            </b-form-checkbox>
+            <dl>
+              <dt>Areas</dt>
+              <dd v-if="selected.area_list.length" class="ml-2 font-italic">{{formattedAreaList}}</dd>
+              <dd v-if="!selected.area_list.length" class="ml-2 font-italic text-muted">None Selected</dd>
+              <dt>Format</dt>
+              <dd class="ml-2 font-italic">{{selected.format.name}}</dd>
+              <dt>Interest Instructions</dt>
+              <dd class="ml-2 font-italic" v-html="selected.instructions_for_interest"></dd>
+            </dl>
           </b-tab>
-          <b-tab title="Participants">
+          <b-tab title="Participant Assignment">
             <view-participants :session="selected"></view-participants>
+          </b-tab>
+          <b-tab title="Schedule">
+            <dl>
+              <dt>Space</dt>
+              <dd v-if="selected.room" class="ml-2 font-italic">{{selected.room.name}}</dd>
+              <dd v-if="!selected.room" class="ml-2 font-italic text-muted">No space selected</dd>
+              <dt>Time</dt>
+              <dd v-if="selected.start_time" class="ml-2 font-italic">{{formattedStartTime}}</dd>
+              <dd v-if="!selected.start_time" class="ml-2 font-italic text-muted">No time selected</dd>
+              <dt>Duration</dt>
+              <dd class="ml-2 font-italic">{{selected.duration}} minutes</dd>
+            </dl>
           </b-tab>
           <b-tab title="Notes">
             <session-notes></session-notes>
@@ -49,6 +90,7 @@ import SessionNotes from './session_notes.vue';
 import ViewParticipants from './view_participants';
 import {personSessionMixin, modelMixin} from '@/mixins';
 import Detail from './detail.vue';
+import { areaMixin, scheduledMixin, startTimeMixin } from './session_fields.mixin';
 // import SessionAdminTab from './session_admin_tab';
 
 export default {
@@ -61,7 +103,10 @@ export default {
   },
   mixins: [
     modelMixin,
-    personSessionMixin
+    personSessionMixin,
+    areaMixin,
+    scheduledMixin,
+    startTimeMixin
   ],
   computed: {
     editLink() {

--- a/app/javascript/sessions/session_sidebar.vue
+++ b/app/javascript/sessions/session_sidebar.vue
@@ -74,6 +74,14 @@
               <dd class="ml-2 font-italic">{{selected.duration}} minutes</dd>
             </dl>
           </b-tab>
+          <b-tab title="Conflicts">
+            <session-conflicts
+              :model="sessionConflictModel"
+              :sessionId="selected.id"
+              :displaySessionInfo="false"
+              ref="conflict-reporting"
+            ></session-conflicts>
+          </b-tab>
           <b-tab title="Notes">
             <session-notes></session-notes>
           </b-tab>
@@ -91,6 +99,8 @@ import ViewParticipants from './view_participants';
 import {personSessionMixin, modelMixin} from '@/mixins';
 import Detail from './detail.vue';
 import { areaMixin, scheduledMixin, startTimeMixin } from './session_fields.mixin';
+import { sessionConflictModel } from '@/store/session_conflict.store';
+import SessionConflicts from '@/conflicts/session_conflicts.vue';
 // import SessionAdminTab from './session_admin_tab';
 
 export default {
@@ -99,7 +109,8 @@ export default {
     SidebarVue,
     Detail,
     SessionNotes,
-    ViewParticipants
+    ViewParticipants,
+    SessionConflicts
   },
   mixins: [
     modelMixin,
@@ -108,6 +119,9 @@ export default {
     scheduledMixin,
     startTimeMixin
   ],
+  data: () => ({
+    sessionConflictModel
+  }),
   computed: {
     editLink() {
       return `/sessions/edit/${this.selected.id}`;

--- a/app/javascript/sessions/session_summary.vue
+++ b/app/javascript/sessions/session_summary.vue
@@ -74,6 +74,7 @@
 <script>
 import { sessionModel } from '@/store/session.store'
 import modelUtilsMixin from '@/store/model_utils.mixin';
+import { scheduledMixin } from './session_fields.mixin';
 
 import PlanoEditor from '../components/plano_editor';
 
@@ -83,15 +84,13 @@ export default {
     PlanoEditor
   },
   mixins: [
-    modelUtilsMixin
+    modelUtilsMixin,
+    scheduledMixin
   ],
   computed: {
     session() {
       return this.selected_model(sessionModel);
     },
-    scheduled() {
-      return this.session ? (!!this.session.room && !!this.session.start_time && !!this.session.duration) : false;
-    }
   },
   methods: {
     saveSession() {

--- a/app/javascript/sessions/session_table.vue
+++ b/app/javascript/sessions/session_table.vue
@@ -25,7 +25,7 @@
       </template>
       <template #cell(area_list)="{ item }">
         <tooltip-overflow v-if="item.area_list" :title="formatAreas(item.area_list)">
-          <span>{{item.area_list && item.area_list.length ? item.area_list.join(", ") : ''}}</span>
+          <span>{{formatAreas(item.area_list)}}</span>
         </tooltip-overflow>
       </template>
       <template #cell(start_time)="{ item }">
@@ -56,6 +56,7 @@ import TooltipOverflow from '../shared/tooltip-overflow';
 import { session_columns as columns } from './session';
 import { sessionModel as model } from '@/store/session.store'
 import dateTimeMixin from '../components/date_time.mixin'
+import { areaMixin } from './session_fields.mixin';
 
 export default {
   name: 'SessionTable',
@@ -65,16 +66,14 @@ export default {
     ModalForm
   },
   mixins: [
-    dateTimeMixin
+    dateTimeMixin,
+    areaMixin
   ],
   data: () => ({
     columns,
     model
   }),
   methods: {
-    formatAreas(areas) {
-      return areas && areas.length ? areas.join(", ") : ''
-    },
     onNew() {
     },
     onSave() {

--- a/app/javascript/sessions/session_tabs.vue
+++ b/app/javascript/sessions/session_tabs.vue
@@ -8,14 +8,12 @@
       </b-tab>
       <b-tab title="Participant Assignment" :active="tab === 'assignment'" lazy>
         <assign-participants
-          v-model="session"
           defaultSortBy='session_assignments.interest_ranking, people.published_name'
           :defaultSortDesc="false"
           :perPage="200"
-          :model="sessionAssignmentModel"
           :defaultFilter="assignmentFilter"
+          :model="sessionAssignmentModel"
           nullsFirst="false"
-          @input="onSessionUpdate"
         ></assign-participants>
       </b-tab>
       <b-tab title="Schedule" :active="tab === 'schedule'" lazy>
@@ -91,9 +89,6 @@ export default {
     }
   },
   methods: {
-    onSessionUpdate(arg) {
-      this.session = arg
-    },
     back() {
       this.$router.push('/sessions')
     },

--- a/app/javascript/sessions/session_tabs.vue
+++ b/app/javascript/sessions/session_tabs.vue
@@ -23,7 +23,7 @@
         <session-conflicts
           :model="sessionConflictModel"
           :sessionId="id"
-          :timezone="timezone"
+          :displaySessionInfo="false"
           ref="conflict-reporting"
         ></session-conflicts>
       </b-tab>
@@ -48,10 +48,6 @@ import SessionSchedule from './session_schedule';
 import SessionConflicts from '../conflicts/session_conflicts.vue'
 import { sessionConflictModel } from '@/store/session_conflict.store'
 import settingsMixin from "@/store/settings.mixin";
-
-import {
-  sessionMixin
-}from '@mixins'
 
 export default {
   name: "SessionTabs",
@@ -98,10 +94,6 @@ export default {
       }
 
       return JSON.stringify(filter)
-    },
-    timezone() {
-      let tz = this.configByName('convention_timezone')
-      return tz
     },
   },
   methods: {

--- a/app/javascript/sessions/session_tabs.vue
+++ b/app/javascript/sessions/session_tabs.vue
@@ -19,7 +19,13 @@
       <b-tab title="Schedule" :active="tab === 'schedule'" lazy>
         <session-schedule></session-schedule>
       </b-tab>
-      <b-tab title="Conflicts" :active="tab === 'conflicts'" lazy disabled>
+      <b-tab title="Conflicts" :active="tab === 'conflicts'">
+        <session-conflicts
+          :model="sessionConflictModel"
+          :sessionId="id"
+          :timezone="timezone"
+          ref="conflict-reporting"
+        ></session-conflicts>
       </b-tab>
       <b-tab title="Notes" :active="tab === 'notes'">
         <session-notes></session-notes>
@@ -39,6 +45,9 @@ import SessionSummary from './session_summary'
 import SessionEdit from './session_edit'
 import SessionNotes from './session_notes'
 import SessionSchedule from './session_schedule';
+import SessionConflicts from '../conflicts/session_conflicts.vue'
+import { sessionConflictModel } from '@/store/session_conflict.store'
+import settingsMixin from "@/store/settings.mixin";
 
 import {
   sessionMixin
@@ -55,13 +64,16 @@ export default {
     AssignParticipants,
     SessionEdit,
     SessionNotes,
-    SessionSchedule
+    SessionSchedule,
+    SessionConflicts
   },
   mixins: [
-    modelUtilsMixin
+    modelUtilsMixin,
+    settingsMixin
   ],
   data: () => ({
     sessionAssignmentModel,
+    sessionConflictModel
   }),
   computed: {
     session() {
@@ -86,7 +98,11 @@ export default {
       }
 
       return JSON.stringify(filter)
-    }
+    },
+    timezone() {
+      let tz = this.configByName('convention_timezone')
+      return tz
+    },
   },
   methods: {
     back() {

--- a/app/javascript/sessions/view_participant_type.vue
+++ b/app/javascript/sessions/view_participant_type.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <dt>{{sessionRoleName}}</dt>
+    <dt>{{sessionRoleLabel || sessionRoleName}}</dt>
     <dd v-if="!myAssignments.length" class="text-muted font-italic ml-2">None Assigned</dd>
     <dd v-for="{person} in myAssignments" :key="person.id" class="ml-2"><router-link :to="'/people/edit/' + person.id">{{person.published_name}}</router-link></dd>
   </div>
@@ -18,6 +18,9 @@ export default {
     },
     sessionRoleName: {
       required: true
+    },
+    sessionRoleLabel: {
+      required: false
     }
   },
   mixins: [

--- a/app/javascript/sessions/view_participants.vue
+++ b/app/javascript/sessions/view_participants.vue
@@ -2,6 +2,7 @@
   <div>
     <view-participant-type :session="session" sessionRoleName="Moderator"></view-participant-type>
     <view-participant-type :session="session" sessionRoleName="Participant"></view-participant-type>
+    <view-participant-type :session="session" sessionRoleName="Invisible" sessionRoleLabel="Invisible Participant"></view-participant-type>
     <view-participant-type :session="session" sessionRoleName="Reserve"></view-participant-type>
   </div>
 </template>

--- a/app/javascript/sessions/view_participants.vue
+++ b/app/javascript/sessions/view_participants.vue
@@ -3,7 +3,7 @@
     <view-participant-type :session="session" sessionRoleName="Moderator"></view-participant-type>
     <view-participant-type :session="session" sessionRoleName="Participant"></view-participant-type>
     <view-participant-type :session="session" sessionRoleName="Invisible" sessionRoleLabel="Invisible Participant"></view-participant-type>
-    <view-participant-type :session="session" sessionRoleName="Reserve"></view-participant-type>
+    <view-participant-type :session="session" sessionRoleName="Reserve" sessionRoleLabel="Reserved"></view-participant-type>
   </div>
 </template>
 

--- a/app/javascript/shared/convention-timezone.mixin.js
+++ b/app/javascript/shared/convention-timezone.mixin.js
@@ -1,0 +1,14 @@
+import { settingsMixin } from "@/store/settings.mixin";
+
+export const conventionTimezoneMixin = {
+  mixins: [
+    settingsMixin,
+  ],
+  computed: {
+    conventionTimezone() {
+      return this.currentSettings?.configs?.find(c => c.parameter === 'convention_timezone')?.parameter_value || 'UTC'
+    },
+  }
+}
+
+export default conventionTimezoneMixin;

--- a/app/javascript/stylesheets/style.scss
+++ b/app/javascript/stylesheets/style.scss
@@ -97,5 +97,14 @@ body {
     &:before {
       border: solid 1px $color-primary-disabled;
     }
+
+    &:after {
+      background-color: $color-primary-disabled;
+    }
+  }
+
+  .custom-control-input:disabled:checked ~ .custom-control-label:after ,
+  .custom-control-input[disabled]:checked ~ .custom-control-label:after {
+    background-color: rgba(white, 0.72);
   }
 }

--- a/app/javascript/stylesheets/style.scss
+++ b/app/javascript/stylesheets/style.scss
@@ -97,9 +97,5 @@ body {
     &:before {
       border: solid 1px $color-primary-disabled;
     }
-
-    &:after {
-      background-color: $color-primary-disabled;
-    }
   }
 }


### PR DESCRIPTION
- fix participant assignment console errors
- area, format, invisible participants, interest instructions, scheduled,
  proofed, schedule tab on flyout
- move open for interest into top section of flyout
- consolidate session field formatting methods
- add conflicts tab to session flyout
  - remove the session date/time in the session tabs
  - change the spacing/borders around multiple conflicts
