### PR TITLE
PLAN-177 fix survey add/edit controls

### DIFF
--- a/app/javascript/surveys/edit-survey-controls.vue
+++ b/app/javascript/surveys/edit-survey-controls.vue
@@ -1,28 +1,30 @@
 <template>
   <div class='position-absolute survey-controls m-3 p-3 border'>
-    <b-button v-b-tooltip.left title="Add a Question" variant="info" class="mb-2 d-block" @click="onNewQuestion()" :disabled="!selectedPage"><b-icon-plus-circle></b-icon-plus-circle></b-button>
+    <b-button v-b-tooltip.left title="Add a Question" variant="info" class="mb-2 d-block" @click="onNewQuestion()"><b-icon-plus-circle></b-icon-plus-circle></b-button>
     <div v-b-tooltip.left title="Import a Question"><b-button disabled variant="info" class="mb-2 d-block"><b-icon-box-arrow-in-right></b-icon-box-arrow-in-right></b-button></div>
-    <b-button v-b-tooltip.left title="Add a Page" variant="info" class="mb-2 d-block" @click="onNewPage" :disabled="!selectedPage"><b-icon-hdd-stack></b-icon-hdd-stack></b-button>
+    <b-button v-b-tooltip.left title="Add a Page" variant="info" class="mb-2 d-block" @click="onNewPage"><b-icon-hdd-stack></b-icon-hdd-stack></b-button>
     <b-button v-b-tooltip.left title="Add a Horizontal Rule" variant="info" class="mb-2 d-block" @click="onNewQuestion('hr')"><b-icon-hr></b-icon-hr></b-button>
     <b-button v-b-tooltip.left title="Add a Text Block" variant="info" class="d-block" @click="onNewQuestion('textonly')"><b-icon-fonts></b-icon-fonts></b-button>
   </div>
 </template>
 
 <script>
-import {mapGetters, mapActions} from 'vuex';
-import { SELECT, SAVE } from '@/store/model.store';
-import { pageModel, questionModel } from '@/store/survey';
-import { pageMixin, questionMixin } from '@mixins';
+import { pageMixin, questionMixin, surveyMixin } from '@/mixins';
 
 export default {
   name: 'EditSurveyControls',
   mixins: [
     pageMixin,
-    questionMixin
+    questionMixin,
+    surveyMixin
   ],
   methods: {
     onNewQuestion(questionType="textfield") {
       let insertAt = 0;
+      if (!this.selectedPage) {
+        this.selectPage(this.selectedQuestion ? this.selectedQuestion.pageId : this.selectedSurveyLastPage)
+        insertAt = this.selectedPageQuestions.length;
+      }
       if(this.selectedQuestion) {
         insertAt = this.getQuestionIndex(this.selectedQuestion) + 1
       }
@@ -30,25 +32,26 @@ export default {
     },
     onNewPage() {
       let questionIds=[]
-      if (!this.selectedQuestion) {
-        // insert a new page with all of the questions in the current page
-        questionIds = Object.keys(this.selectedPage.questions)
-      } else {
-        // insert a new page with the questions below the currently selected question
-        let targetSortOrder = this.selectedQuestion.sort_order
-        for(let question of this.selectedPageQuestions) {
-          if(question.sort_order > targetSortOrder) {
-            questionIds.push(question.id)
+      let insertAt = this.getNbrSurveyPages(this.survey);
+      if (this.selectedPage) {
+        if (!this.selectedQuestion) {
+          // insert a new page with all of the questions in the current page
+          questionIds = Object.keys(this.selectedPage.questions)
+        } else {
+          // insert a new page with the questions below the currently selected question
+          let targetSortOrder = this.selectedQuestion.sort_order
+          for(let question of this.selectedPageQuestions) {
+            if(question.sort_order > targetSortOrder) {
+              questionIds.push(question.id)
+            }
           }
         }
-      }
-      let insertAt = Object.keys(this.survey.pages).length
-      if (this.selectedPage) {
         // if there's a selected page, insert this page after.
         insertAt = this.getPageIndex(this.selectedPage.id) + 1
       }
       this.newPage({surveyId: this.survey.id, questionIds, insertAt}).then((newPage) => {
-        this.fetchSelectedSurvey()
+        this.fetchSelectedSurvey();
+        this.unselectQuestion();
       })
     },
   }

--- a/app/javascript/surveys/survey.mixin.js
+++ b/app/javascript/surveys/survey.mixin.js
@@ -24,6 +24,9 @@ export const surveyMixin = {
     },
     selectedSurveyFirstPage() {
       return this.survey && this.selectedSurveyPages[0];
+    },
+    selectedSurveyLastPage() {
+      return this.survey && this.selectedSurveyPages[this.getNbrSurveyPages(this.survey) - 1];
     }
   },
   methods: {


### PR DESCRIPTION
If there is no page and no question selected:
- add page adds a page to the bottom
- add question/hr/text adds a question to the bottom of the last page

If there is a page but no question selected:
- add page adds a page after the current page, and all the questions on the current page should move to the new page
- add question/hr/text adds a question as the first question on the selected page

If there is a question but no page selected:
- select the question's page as the page

If there is both a question and a page selected:
- add page adds a page after the currently selected question, taking all the questions below the currently selected question
- add question/hr/text adds a question after the currently selected question