### PR TITLE
Plan-390 get rid of wrong other

### DIFF
--- a/db/seeds/format.seeds.rb
+++ b/db/seeds/format.seeds.rb
@@ -42,9 +42,9 @@ unless Format.find_by_name('Meetup')
   )
 end
 
-unless Format.find_by_name('Other (add to notes)')
+unless Format.find_by_name('Other')
   Format.create!(
-    name: 'Other (add to notes)',
+    name: 'Other',
     position: 7
   )
 end


### PR DESCRIPTION
so we had a seed that recreated the "Other (add to notes)" format. That has been corrected