### PR TITLE
1.3.3

### DIFF
--- a/app/controllers/session_assignments_controller.rb
+++ b/app/controllers/session_assignments_controller.rb
@@ -31,7 +31,7 @@ class SessionAssignmentsController < ResourceController
   def serializer_includes
     # remove included data for now to speed up loads
     [
-      # :person,
+      :person,
       # :session,
       # :'session.format'
     ]

--- a/app/serializers/session_assignment_serializer.rb
+++ b/app/serializers/session_assignment_serializer.rb
@@ -6,7 +6,7 @@ class SessionAssignmentSerializer
              :visibility, :state, :planner_notes,
              :interested, :interest_ranking, :interest_notes, :interest_role
 
-  belongs_to :person, lazy_load_data: true,
+  belongs_to :person,
              if: Proc.new { |record| record.session },
              links: {
                self: -> (object, params) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,11 +7,8 @@ This software is open source! If you'd like to contribute, please email planoram
 
 [Planorama Data Privacy & Protection Policy](/planorama/privacy)
 
-Production version: 1.3.1
+Production version: 1.3.2
 
-Staging version: 1.3.1
+Staging version: 1.3.2
 
 <script type="text/javascript" src="https://chicon-planorama.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/r5gghz/b/3/bc54840da492f9ca037209037ef0522a/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=816c99a7"></script>
-
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ This software is open source! If you'd like to contribute, please email planoram
 
 [Planorama Data Privacy & Protection Policy](/planorama/privacy)
 
-Production version: 1.3.2
+Production version: 1.3.3
 
-Staging version: 1.3.2
+Staging version: 1.3.3
 
 <script type="text/javascript" src="https://chicon-planorama.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/r5gghz/b/3/bc54840da492f9ca037209037ef0522a/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=816c99a7"></script>


### PR DESCRIPTION
# Release notes - Planorama - Version 1.3.3

- Fix some participants not showing up in session flyout + edit areas

### Bug

[PLAN-443](https://chicon-planorama.atlassian.net/browse/PLAN-443) People missing from assignment UIs

## What's Changed
* PLAN-443 make sure people are loaded if need be for assignments by @balen in https://github.com/ChicagoWorldcon/planorama/pull/268


**Full Changelog**: https://github.com/ChicagoWorldcon/planorama/compare/v1.3.2...v1.3.3