### PR TITLE
1.3.5

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ This software is open source! If you'd like to contribute, please email planoram
 
 [Planorama Data Privacy & Protection Policy](/planorama/privacy)
 
-Production version: 1.3.3
+Production version: 1.3.4
 
-Staging version: 1.3.3
+Staging version: 1.3.4
 
 <script type="text/javascript" src="https://chicon-planorama.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/r5gghz/b/3/bc54840da492f9ca037209037ef0522a/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=816c99a7"></script>


### PR DESCRIPTION
# Release notes - Planorama - Version 1.3.5

- Fix information about session interest, which temporarily went missing.
- Fix Schedule by Participants report to run properly.

### Bug

[PLAN-467](https://chicon-planorama.atlassian.net/browse/PLAN-467) Fix missing session information in picker

[PLAN-465](https://chicon-planorama.atlassian.net/browse/PLAN-465) Fix sched by participants report

## What's Changed
* 1.3.4 into staging by @Gailbear in https://github.com/ChicagoWorldcon/planorama/pull/274
* PLAN-465 sched by participants need to be just scheduled session (so check sta… by @balen in https://github.com/ChicagoWorldcon/planorama/pull/279
* PLAN-467 fix session selector display by @balen in https://github.com/ChicagoWorldcon/planorama/pull/280


**Full Changelog**: https://github.com/ChicagoWorldcon/planorama/compare/v1.3.4...v1.3.5