### PR TITLE
fix typo - extraneous lines in migration

### DIFF
--- a/db/migrate/20220620180039_person_exclusion_conflicts.rb
+++ b/db/migrate/20220620180039_person_exclusion_conflicts.rb
@@ -29,6 +29,3 @@ class PersonExclusionConflicts < ActiveRecord::Migration[6.1]
     SQL
   end
 end
-
-('20220620181659'),
-('20220620181701');


### PR DESCRIPTION
fix migration typo