### PR TITLE
move view creation to a helper. So fix migrations to use that

### DIFF
--- a/db/migrate/20220620180030_add_duration_to_sched_view.rb
+++ b/db/migrate/20220620180030_add_duration_to_sched_view.rb
@@ -1,35 +1,10 @@
 class AddDurationToSchedView < ActiveRecord::Migration[6.1]
   def up
-    # This will be extended to union the other conflicts
-    execute <<-SQL
-      CREATE OR REPLACE VIEW person_schedules AS
-        SELECT p.id AS person_id,
-           p.name,
-           p.published_name,
-           sa.id AS session_assignment_id,
-           sart.id AS session_assignment_role_type_id,
-           sart.name AS session_assignment_name,
-           sart.role_type AS session_assignment_role_type,
-           sa.sort_order,
-           sessions.id AS session_id,
-           sessions.title,
-           sessions.start_time,
-           (sessions.start_time + ((sessions.duration || ' minute'::text))::interval) AS end_time,
-           sessions.room_id,
-           sessions.format_id,
-           concat(p.id, ':', sa.id) AS id,
-           sessions.duration
-          FROM (((public.session_assignments sa
-            JOIN public.session_assignment_role_type sart ON (((sart.id = sa.session_assignment_role_type_id) AND (sart.role_type = 'participant'::public.assignment_role_enum))))
-            JOIN public.people p ON ((p.id = sa.person_id)))
-            LEFT JOIN public.sessions ON ((sessions.id = sa.session_id)))
-         WHERE ((sa.session_assignment_role_type_id IS NOT NULL) AND (sessions.room_id IS NOT NULL) AND (sessions.start_time IS NOT NULL));
-    SQL
+    MigrationHelpers::PlanoViews.drop_views
+    MigrationHelpers::PlanoViews.create_views
   end
 
   def down
-    execute <<-SQL
-      DROP VIEW IF EXISTS person_schedules;
-    SQL
+    MigrationHelpers::PlanoViews.drop_views
   end
 end

--- a/db/migrate/20220620180039_person_exclusion_conflicts.rb
+++ b/db/migrate/20220620180039_person_exclusion_conflicts.rb
@@ -1,31 +1,11 @@
 class PersonExclusionConflicts < ActiveRecord::Migration[6.1]
   def up
-    # This will be extended to union the other conflicts
-    execute <<-SQL
-      CREATE OR REPLACE VIEW person_exclusion_conflicts AS
-       SELECT concat(person_schedules.person_id, ':', es.exclusion_id, ':', person_schedules.session_id) AS id,
-          person_schedules.person_id,
-          es.exclusion_id,
-          es.session_id AS excluded_session_id,
-          person_schedules.session_id,
-          person_schedules.title,
-          person_schedules.start_time,
-          person_schedules.end_time,
-          person_schedules.duration,
-          person_schedules.session_assignment_role_type_id,
-          person_schedules.session_assignment_name,
-          person_schedules.session_assignment_role_type
-         FROM (((public.person_schedules
-           LEFT JOIN public.person_exclusions pe ON ((pe.person_id = person_schedules.person_id)))
-           JOIN public.exclusions_sessions es ON ((es.exclusion_id = pe.exclusion_id)))
-           LEFT JOIN public.sessions s ON ((s.id = es.session_id)))
-        WHERE ((person_schedules.session_id <> s.id) AND (person_schedules.start_time >= s.start_time) AND ((person_schedules.start_time <= (s.start_time + ((s.duration || ' minute'::text))::interval)) OR ((person_schedules.end_time >= s.start_time) AND (person_schedules.end_time <= (s.start_time + ((s.duration || ' minute'::text))::interval)))));
-    SQL
+    MigrationHelpers::PlanoViews.drop_views
+    MigrationHelpers::PlanoViews.create_views
   end
 
   def down
-    execute <<-SQL
-      DROP VIEW IF EXISTS person_exclusion_conflicts;
-    SQL
+    MigrationHelpers::PlanoViews.drop_views
   end
+
 end


### PR DESCRIPTION
I moved view creation to a helper, so for deployment I fixed the recent view migration to use that so as to avoid conflicts with startup checks as well