### PR TITLE
PLAN-402 allow edit of survey title and description

### DIFF
--- a/app/javascript/surveys/edit-survey.vue
+++ b/app/javascript/surveys/edit-survey.vue
@@ -1,14 +1,5 @@
 <template>
   <div class="survey">
-    <b-form-group
-      class="mx-3"
-      v-if="survey"
-      id="survey-description-group"
-      label="Survey Description"
-      label-for="survey-description"
-    >
-      <b-form-textarea id="survey-description" v-model="survey.description" @blur="saveSurvey()"></b-form-textarea>
-    </b-form-group>
     <edit-survey-controls></edit-survey-controls>
     <edit-survey-page
       v-for="(p, i) in selectedSurveyPages"

--- a/app/javascript/surveys/manage-survey.vue
+++ b/app/javascript/surveys/manage-survey.vue
@@ -11,6 +11,15 @@
     >
       <b-form-input id="survey-name" type="text" v-model="survey.name" @blur="saveSurvey()"></b-form-input>
     </b-form-group>
+    <b-form-group
+      class="mx-3"
+      v-if="survey"
+      id="survey-description-group"
+      label="Survey Description"
+      label-for="survey-description"
+    >
+      <b-form-textarea id="survey-description" v-model="survey.description" @blur="saveSurvey()"></b-form-textarea>
+    </b-form-group>
     <b-alert :show="survey.public" variant="warning" class="alert-bright mx-3">{{SURVEY_PUBLIC_NO_EDIT}}</b-alert>
     <b-tabs>
       <b-tab button-id="questionTab" title="Question" :active="!responses && !survey.public" lazy :disabled="survey.public">

--- a/app/javascript/surveys/manage-survey.vue
+++ b/app/javascript/surveys/manage-survey.vue
@@ -9,7 +9,7 @@
       label="Survey Name"
       label-for="survey-name"
     >
-      <b-form-input id="survey-name" type="text" v-model="survey.name" @blur="saveSurvey()" :disabled="survey.public"></b-form-input>
+      <b-form-input id="survey-name" type="text" v-model="survey.name" @blur="saveSurvey()"></b-form-input>
     </b-form-group>
     <b-alert :show="survey.public" variant="warning" class="alert-bright mx-3">{{SURVEY_PUBLIC_NO_EDIT}}</b-alert>
     <b-tabs>

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -47,6 +47,8 @@ class Survey < ApplicationRecord
     return if self.new_record?
 
     return if self.public && self.public_changed? # to allow for changing to "published"
+    return if self.public && self.name_changed?
+    return if self.public && self.description_changed?
 
     raise 'can not delete or update a survey that is public' if self.public
   end


### PR DESCRIPTION
@Gailbear we need the UI to allow for the description to be edited. I turned off the disable for title, but since description is grouped with the rest of the edit etc I think there is some untangling to do,