### PR TITLE
PLAN-239 The clone button is disabled if selected_items.length===0

### DIFF
--- a/app/javascript/components/table_vue.vue
+++ b/app/javascript/components/table_vue.vue
@@ -27,7 +27,7 @@
 
       <div class="d-flex justify-content-end">
         <div class="d-inline mx-1" title="clone" v-if="showClone">
-          <b-button @click="$emit('clone')" variant="primary" title="clone">
+          <b-button @click="$emit('clone')" variant="primary" title="clone" :disabled='selected_items.length===0' >
             <b-icon-files></b-icon-files>
           </b-button>
         </div>


### PR DESCRIPTION
This fixes the problem of an enabled clone button for all tables where nothing has been selected