### PR TITLE
PLAN-588 we do not want to map the hugo rehersal to exclusion

### DIFF
--- a/lib/tasks/chicon.rake
+++ b/lib/tasks/chicon.rake
@@ -77,7 +77,7 @@ namespace :chicon do
   task map_session_to_exclusion: :environment do
     mapping = {
       'Hugo Award Ceremony' => ['Hugo Award Ceremony'],
-      'Hugo Award Ceremony rehearsal' => ['Hugo Award Ceremony Rehersal'],
+      # 'Hugo Award Ceremony rehearsal' => ['Hugo Award Ceremony Rehersal'],
       'Masquerade' => ['Masquerade'],
       'Masquerade rehearsal' => ['Masquerade Rehersal'],
       'Opening Ceremony' => ['Opening Ceremony'],


### PR DESCRIPTION
removed hugo rehersal from exclusion mapping as requested, adjusted rake so it is not recreated