### PR TITLE
PLAN-596 PLAN-598 PLAN-599 fixes for draft schedule

### DIFF
--- a/app/javascript/dashboard/dashboard.vue
+++ b/app/javascript/dashboard/dashboard.vue
@@ -119,11 +119,17 @@
 <script>
 import {http} from '@/http';
 import { personSessionMixin, toastMixin } from '@/mixins';
+import { mapActions } from 'vuex'; 
+import { FETCH_WORKFLOWS } from '@/store/schedule_workflow';
+
 
 export default {
   name: "Dashboard",
   mixins: [personSessionMixin, toastMixin],
   methods: {
+    ...mapActions({
+      fetchScheduleWorkflows: FETCH_WORKFLOWS
+    }),
     makeError(event) {
       throw new Error("look an error")
     },
@@ -136,6 +142,10 @@ export default {
     makeGenericError() {
       this.toastPromise(http.post("/does-not-exist"))
     }
+  },
+  mounted() {
+    // stopgap for not loading the session workflows earlier when logged in 
+    this.fetchScheduleWorkflows();
   }
 }
 </script>

--- a/app/javascript/people/people.js
+++ b/app/javascript/people/people.js
@@ -64,11 +64,21 @@ export const people_columns = [
     sortable: false
   },
   {
+    key: 'draft_comments',
+    label: 'Draft Comments',
+    sortable: false
+  },
+  {
     key: 'firm_approval',
     label: 'Firm Approved',
     search_key: 'firm_person_schedule_approvals.approved',
     type: "select",
     choices: personScheduleApprovalStateOptionsForSearch,
+    sortable: false
+  },
+  {
+    key: 'firm_comments',
+    label: 'Firm Comments',
     sortable: false
   },
   // {
@@ -110,21 +120,14 @@ export const people_columns = [
     sortable: false
   },
   {
-    key: 'opted_in',
-    label: 'Opted In',
-    type: "radio",
-    choices: [{label: "Yes", value: "true"}, {label: "No", value: "false"}],
-    sortable: false
-  },
-  {
     key: 'comments',
-    label: 'Comments',
+    label: 'Notes',
     type: "text",
     sortable: false
   },
   {
     key: 'current_sign_in_at',
-    label: 'Signed In At',
+    label: 'Last Logged In',
     sortable: false
   }
 ];

--- a/app/javascript/people/people_table.vue
+++ b/app/javascript/people/people_table.vue
@@ -105,10 +105,32 @@
         </span>
       </template>
       <template #cell(draft_approval)="{ item }">
-        {{ approved(item.person_schedule_approvals, 'draft') }}
+        <div v-if="draftSchedule">
+          {{ approved(item.person_schedule_approvals, 'draft') }}
+        </div>
+        <div v-else class="text-muted text-center"> &mdash; </div>
+      </template>
+      <template #cell(draft_comments)="{ item }">
+        <div v-if="draftSchedule">
+          <tooltip-overflow :title="comments(item.person_schedule_approvals, 'draft')">
+            {{ comments(item.person_schedule_approvals, 'draft') }}
+          </tooltip-overflow>
+        </div>
+        <div v-else class="text-muted text-center"> &mdash; </div>
       </template>
       <template #cell(firm_approval)="{ item }">
-        {{ approved(item.person_schedule_approvals, 'firm') }}
+        <div v-if="firmSchedule">
+          {{ approved(item.person_schedule_approvals, 'firm') }}
+        </div>
+        <div v-else class="text-muted text-center">&mdash;</div>
+      </template>
+      <template #cell(firm_comments)="{ item }">
+        <div v-if="firmSchedule">
+          <tooltip-overflow :title="comments(item.person_schedule_approvals, 'firm')">
+            {{ comments(item.person_schedule_approvals, 'firm') }}
+          </tooltip-overflow>
+        </div>
+        <div v-else class="text-muted text-center"> &mdash; </div>
       </template>
     </table-vue>
   </div>
@@ -127,6 +149,8 @@ import PeopleSessionNames from './people_session_names';
 
 import searchStateMixin from '../store/search_state.mixin'
 import { formatPersonScheduleApprovalState } from '@/store/person_schedule_approval';
+import { FETCH_WORKFLOWS, scheduleWorkflowMixin } from '@/store/schedule_workflow';
+import { mapActions } from 'vuex';
 
 export default {
   name: 'PeopleTable',
@@ -136,11 +160,12 @@ export default {
     ModalForm,
     PersonAdd,
     PersonConStateSelector,
-    PeopleSessionNames
+    PeopleSessionNames,
   },
   mixins: [
     modelUtilsMixin,
-    searchStateMixin
+    searchStateMixin,
+    scheduleWorkflowMixin,
   ],
   data: () => ({
     columns,
@@ -155,9 +180,16 @@ export default {
     }
   },
   methods: {
+    ...mapActions({
+      fetchScheduleWorkflows: FETCH_WORKFLOWS,
+    }),
     approved(approvals, state) {
       let v = Object.values(approvals).find( o => o.workflow_state == state);
       return formatPersonScheduleApprovalState(v?.approved)
+    },
+    comments(approvals, state) {
+      let v = Object.values(approvals).find( o => o.workflow_state == state);
+      return v?.approved === 'no' ? v.comments : '';
     },
     queries(searchEmails) {
       let queries = {
@@ -227,6 +259,7 @@ export default {
     })
 
     this.$refs['people-table'].fetchPaged()
+    this.fetchScheduleWorkflows();
   }
 }
 </script>

--- a/app/javascript/people/person_tabs.vue
+++ b/app/javascript/people/person_tabs.vue
@@ -41,11 +41,11 @@
             :person_id="person.id"
           ></session-ranker>
         </b-tab>
-        <b-tab title="Draft Schedule" lazy v-if="displayDraftSchedule" :active="tab === 'draft-schedule'">
-          <person-draft-schedule></person-draft-schedule>
-        </b-tab>
         <b-tab :title="liveScheduleTitle" lazy v-if="currentUserIsAdmin || currentUserIsStaff || firmSchedule" :active="tab === 'schedule'">
           <person-live-schedule></person-live-schedule>
+        </b-tab>
+        <b-tab title="Draft Schedule" lazy v-if="displayDraftSchedule" :active="tab === 'draft-schedule'">
+          <person-draft-schedule></person-draft-schedule>
         </b-tab>
         <b-tab title="Admin" lazy v-if="currentUserIsAdmin || currentUserIsStaff" :active="tab === 'admin'">
           <people-admin-tab></people-admin-tab>
@@ -77,11 +77,12 @@ import { sessionAssignmentModel } from '@/store/session_assignment.store'
 import personSessionMixin from '@/auth/person_session.mixin';
 import settingsMixin from "@/store/settings.mixin";
 import modelUtilsMixin from '@/store/model_utils.mixin';
-import { scheduleWorkflowMixin } from '@/store/schedule_workflow';
+import { scheduleWorkflowMixin, FETCH_WORKFLOWS } from '@/store/schedule_workflow';
 
 const { DateTime } = require("luxon");
 
 import VueRouter from 'vue-router';
+import { mapActions } from 'vuex';
 const { isNavigationFailure, NavigationFailureType } = VueRouter;
 
 // This needs to be kept in sync with the tab order above
@@ -91,8 +92,8 @@ const tabsArray = [
   'availability',
   'session-selection',
   'session-ranking',
-  'draft-schedule',
   'schedule',
+  'draft-schedule',
   'admin'
 ]
 
@@ -151,6 +152,9 @@ export default {
     }
   },
   methods: {
+    ...mapActions({
+      fetchScheduleWorkflows: FETCH_WORKFLOWS
+    }),
     back() {
       this.$router.push('/people')
     },
@@ -191,6 +195,7 @@ export default {
         }
       }
     )
+    this.fetchScheduleWorkflows();
   },
   beforeRouteLeave(to, from, next) {
     if (from.path.match(/.*profile.*/) && to.path === '/people') {

--- a/app/javascript/schedule/schedule_settings.vue
+++ b/app/javascript/schedule/schedule_settings.vue
@@ -11,11 +11,13 @@
           <b-form-checkbox id="firm-schedule-checkbox" switch v-model="localFirmSchedule" @change="openFirmConfirm" :disabled="!localDraftSchedule || localFirmSchedule" inline aria-describedby="firm-schedule-date"></b-form-checkbox>
           <span class="small text-muted" id="firm-schedule-date" v-if="localFirmSchedule">{{firmScheduledAtText}}</span>
         </b-form-group>
-        <h2>REMOVE ME BEFORE PRODUCTION</h2>
-        <b-button variant="primary" @click="reset()">Reset for Testing</b-button>
-        <span>THIS DELETES THE SNAPSHOT AND YOU CAN'T EVER GET IT BACK</span>
-        <div class="mt-3">Note: this minecart isn't actually hooked up to any status yet. So while it does actually produce a snapshot, the toggle won't
-        reflect reality if you reload. There's some TODOs in here. If you try to snapshot and get an error, reset first.
+        <div v-if="NODE_ENV && NODE_ENV !== 'production'">
+          <h2>REMOVE ME BEFORE PRODUCTION</h2>
+          <b-button variant="primary" @click="reset()">Reset for Testing</b-button>
+          <span>THIS DELETES THE SNAPSHOT AND YOU CAN'T EVER GET IT BACK</span>
+          <div class="mt-3">Note: this minecart isn't actually hooked up to any status yet. So while it does actually produce a snapshot, the toggle won't
+          reflect reality if you reload. There's some TODOs in here. If you try to snapshot and get an error, reset first.
+          </div>
         </div>
       </div>
     </div>
@@ -56,7 +58,8 @@ export default {
     localFirmSchedule: false,
     firmScheduleConfirmed: false,
     SCHEDULE_DRAFT_CONFIRM_MESSAGE,
-    SCHEDULE_FIRM_CONFIRM_MESSAGE
+    SCHEDULE_FIRM_CONFIRM_MESSAGE,
+    NODE_ENV
   }),
   computed: {
     draftScheduledAtText() {

--- a/app/javascript/store/person_schedule_approval/person_schedule_approval.model.js
+++ b/app/javascript/store/person_schedule_approval/person_schedule_approval.model.js
@@ -9,13 +9,16 @@ export const PersonScheduleApprovalState = {
 }
 
 export const personScheduleApprovalStateOptions = [
-  {text: 'Not Set', value: PersonScheduleApprovalState.NOT_SET},
+  {text: 'Not Set', value: PersonScheduleApprovalState.NOT_SET, disabled: true},
   {text: 'Yes', value: PersonScheduleApprovalState.YES},
   {text: 'No', value: PersonScheduleApprovalState.NO},
 ];
 
-export const personScheduleApprovalStateOptionsForSearch = 
-  personScheduleApprovalStateOptions.map(i => ({...i, label: i.text}))
+export const personScheduleApprovalStateOptionsForSearch = [
+  {label: 'Not Set', value: PersonScheduleApprovalState.NOT_SET},
+  {label: 'Yes', value: PersonScheduleApprovalState.YES},
+  {label: 'No', value: PersonScheduleApprovalState.NO},
+];
 
 export const formatPersonScheduleApprovalState = (psa) => {
   if (!psa) {

--- a/app/javascript/store/schedule_workflow/schedule_workflow.mixin.js
+++ b/app/javascript/store/schedule_workflow/schedule_workflow.mixin.js
@@ -1,5 +1,5 @@
 import { mapGetters, mapActions } from 'vuex';
-import { FETCH_WORKFLOWS, RESET_DRAFT_SCHEDULE, RESET_FIRM_SCHEDULE, SET_DRAFT_SCHEDULE, SET_FIRM_SCHEDULE } from './schedule_workflow.actions';
+import { FETCH_WORKFLOWS, SET_DRAFT_SCHEDULE, SET_FIRM_SCHEDULE } from './schedule_workflow.actions';
 import { DateTime } from 'luxon';
 import { toastMixin } from '@/mixins';
 import { SCHEDULE_DRAFT_SUCCESS_MESSAGE, SCHEDULE_FIRM_SUCCESS_MESSAGE } from '@/constants/strings';
@@ -42,10 +42,10 @@ export const scheduleWorkflowMixin = {
       return this.draftSchedule && !this.firmSchedule;
     },
     draftScheduledAt() {
-      return DateTime.fromISO(this.draftScheduleWorkflow?.set_at).toLocaleString();
+      return DateTime.fromISO(this.draftScheduleWorkflow?.set_at).toFormat('D, t ZZZZ');
     },
     firmScheduledAt() {
-      return DateTime.fromISO(this.firmScheduleWorkflow?.set_at).toLocaleString();
+      return DateTime.fromISO(this.firmScheduleWorkflow?.set_at).toFormat('D, t ZZZZ');
     }
   },
   methods: {

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -33,6 +33,7 @@
       <h1 class="header">Down for Maintenance</h1>
       <img src="./warning_triangle.png" height="34" alt="triangle with exclamation point inside" class="warning-icon"/>
       <p class="text">We apologize for any inconvenience. Rest assured, your data is all safe. We'll be done soon; please check back in a few minutes.</p>
+      <p>To return to the site, click <a href="/">here</a>. Reloading the page won't tell you if the site is back up yet.</p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
- format date for schedule settings
- add last edited for person schedule approval
- disable “not set” as selectable radio on approval form
- show dashes in schedule approval columns until appropriate schedule is released
- draft comment and firm comment columns in people table, with ellipses tooltip
- blank out display in person box when state is not “no” but do not  delete data
- pull schedule workflow on profile tab load
- reverse order of live and draft tabs
- change the comment column in people table to be “notes”
- change signed in column to “last logged in”
- take out “opted in” column
- add home link to maintenance page