### PR TITLE
PLAN-603-tooltip-over-draft-firm-acceptance-comment-does-not-preserve-line-breaks

### DIFF
--- a/app/javascript/people/people_table.vue
+++ b/app/javascript/people/people_table.vue
@@ -111,9 +111,9 @@
       </template>
       <template #cell(draft_comments)="{ item }">
         <div v-if="draftSchedule">
-          <tooltip-overflow :title="comments(item.person_schedule_approvals, 'draft')">
+          <tooltip-overflow-keep-newlines :title="comments(item.person_schedule_approvals, 'draft')">
             {{ comments(item.person_schedule_approvals, 'draft') }}
-          </tooltip-overflow>
+          </tooltip-overflow-keep-newlines>
         </div>
         <div v-else class="text-muted text-center"> &mdash; </div>
       </template>
@@ -125,9 +125,9 @@
       </template>
       <template #cell(firm_comments)="{ item }">
         <div v-if="firmSchedule">
-          <tooltip-overflow :title="comments(item.person_schedule_approvals, 'firm')">
+          <tooltip-overflow-keep-newlines :title="comments(item.person_schedule_approvals, 'firm')">
             {{ comments(item.person_schedule_approvals, 'firm') }}
-          </tooltip-overflow>
+          </tooltip-overflow-keep-newlines>
         </div>
         <div v-else class="text-muted text-center"> &mdash; </div>
       </template>
@@ -139,6 +139,7 @@
 import TableVue from '../components/table_vue';
 import ModalForm from '../components/modal_form';
 import TooltipOverflow from '../shared/tooltip-overflow';
+import TooltipOverflowKeepNewlines from "@/shared/tooltip-overflow-keep-newlines";
 import PersonAdd from '../people/person_add.vue';
 import { people_columns as columns } from './people';
 import { personModel as model } from '@/store/person.store'
@@ -156,6 +157,7 @@ import { DateTime } from 'luxon';
 export default {
   name: 'PeopleTable',
   components: {
+    TooltipOverflowKeepNewlines,
     TableVue,
     TooltipOverflow,
     ModalForm,
@@ -267,7 +269,7 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 .col-name-field div {
   width: 8rem;
 }

--- a/app/javascript/shared/tooltip-overflow-keep-newlines.vue
+++ b/app/javascript/shared/tooltip-overflow-keep-newlines.vue
@@ -1,0 +1,37 @@
+<template>
+  <!-- Use v-b-tooltip.html to handle cases when the test is html -->
+  <span v-b-tooltip.html="{customClass: 'truncated-tooltip'}"
+    :title="title"
+        class="text-truncate truncated-span"
+  >
+    <slot>{{title}}</slot>
+  </span>
+</template>
+
+<script>
+export default {
+  name: "TooltipOverflowKeepNewlines",
+  props: {
+    title: {
+      type: String,
+    }
+  },
+}
+</script>
+
+<style lang="scss">
+.truncated-tooltip {
+  .tooltip-inner {
+    max-width: 30rem;
+    white-space: pre-wrap;
+  }
+}
+.truncated-span {
+  max-width: 15rem;
+  display: inline-block;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+</style>


### PR DESCRIPTION
Created new tooltip component that preserves newlines