### PR TITLE
PLAN-672 Add participant attendance type as tag in conclar output

### DIFF
--- a/app/serializers/conclar/participant_serializer.rb
+++ b/app/serializers/conclar/participant_serializer.rb
@@ -50,7 +50,7 @@ class Conclar::ParticipantSerializer < ActiveModel::Serializer
   attribute :tags do
     res = []
 
-    res.concat [object.attendance_type]    # in person, virtual, hybrid
+    res.concat ["Attendance: ".concat( object.attendance_type )]    # in person, virtual, hybrid
 
     res
   end

--- a/app/serializers/conclar/participant_serializer.rb
+++ b/app/serializers/conclar/participant_serializer.rb
@@ -46,5 +46,12 @@ class Conclar::ParticipantSerializer < ActiveModel::Serializer
     res
   end
 
-  # tags - not supported yet
+  # tags
+  attribute :tags do
+    res = []
+
+    res.concat [object.attendance_type]    # in person, virtual, hybrid
+
+    res
+  end
 end

--- a/db/seeds/development/person.seeds.rb
+++ b/db/seeds/development/person.seeds.rb
@@ -41,7 +41,8 @@ if Person.count < 100
           instagram: username,
           flickr: username,
           reddit: username,
-          tiktok: username
+          tiktok: username,
+          attendance_type: ['in person', 'virtual', 'hybrid'].sample
       )
       e = name.gsub(' ', '_') + i.to_s + '@test.com'
       EmailAddress.create(


### PR DESCRIPTION
I'd like to add the attendance type field to the participant output used for conclar as a tag so that we can add tags to the people page.