### PR TITLE
PLAN-677 Stag paging issue

### DIFF
--- a/app/javascript/profile/session_ranker.vue
+++ b/app/javascript/profile/session_ranker.vue
@@ -184,7 +184,7 @@ export default {
         this.removeInterest(this.assignment, this.person_id).then(
           (res) => {
             this.assignment = null
-            this.fetchPaged()
+            this.fetchAll()
           }
         )
       }
@@ -222,7 +222,7 @@ export default {
     // If there is no pager we need to get the initial collection somehow
     // Order should be by created_at date and ranking ...
     this.assignment = null
-    this.fetchPaged();
+    this.fetchAll();
   }
 }
 </script>

--- a/app/javascript/sessions/assign_participants.vue
+++ b/app/javascript/sessions/assign_participants.vue
@@ -90,19 +90,19 @@ export default {
   },
   methods: {
     reorder() {
-      this.fetchPaged(false)
+      this.fetchAll(false)
     },
     saveAssignment(assignment) {
       this.save(assignment).then(
         () => {
           // TODO?
           // this.refreshSession()
-          this.fetchPaged(false)
+          this.fetchAll(false)
         }
       ).catch(
         () => {
           // this.refreshSession()
-          this.fetchPaged(false)
+          this.fetchAll(false)
         }
       )
     },
@@ -120,7 +120,7 @@ export default {
   mounted() {
     // If there is no pager we need to get the initial collection somehow
     // Order should be by created_at date and ranking ...
-    this.fetchPaged(false); // false to not clear store of existing models
+    this.fetchAll(false); // false to not clear store of existing models
     this.select_model('session_assignment', null)
     this.select_model('person', null);
   }

--- a/app/javascript/store/table.mixin.js
+++ b/app/javascript/store/table.mixin.js
@@ -87,7 +87,7 @@ export const tableMixin = {
         this.tempCurrentPage = this.currentPage;
       }
     },
-    fetchPaged(clear=true) {
+    fetchAll(clear=true, perPage=null) {
       this.tableBusy = true;
       this.shall_clear = clear
       let _filter = JSON.stringify(this.filter)
@@ -108,7 +108,8 @@ export const tableMixin = {
         // What URL does this use
         this.fetch(
           {
-            perPage: this.perPage,
+            // THIS IS THE PROBLEM
+            perPage: perPage,
             sortOrder: this.sortDesc ? 'desc' : 'asc',
             sortBy: this.sortBy,
             filter: _filter,
@@ -127,6 +128,9 @@ export const tableMixin = {
           res(data);
         }).catch(rej).finally(() => this.tableBusy = false); // TODO maybe actually handle it here??
       })
+    },
+    fetchPaged(clear=true) {
+      this.fetchAll(clear, this.perPage);
     }
   },
   mounted() {


### PR DESCRIPTION
table mixin is used for fetching collections with params. Not all collections should be paged. New default page breaks places were we do not want paged results. Added fetchAll which factors out common code and makes page optional.