### PR TITLE
adjust pub diffs so add and drops do not also create info about title… 2.0

### DIFF
--- a/app/controllers/reports/schedule_reports_controller.rb
+++ b/app/controllers/reports/schedule_reports_controller.rb
@@ -48,9 +48,11 @@ class Reports::ScheduleReportsController < ApplicationController
           ((!change[:changes]['room_id'][0] && change[:changes]['room_id'][1]) ||
           (!change[:changes]['start_time'][0] && change[:changes]['start_time'][1]))
           session_added_row(session_added, change, date_time_style)
+          next
         else
           if (change[:changes]['room_id'] && !change[:changes]['room_id'][1]) || (change[:changes]['start_time'] && !change[:changes]['start_time'][1])|| change[:event] == 'destroy'
             session_removed_row(session_removed, change)
+            next
           else
             if change[:changes]['room_id']
               session_room_change_row(session_room_changed, change)


### PR DESCRIPTION
Small tweak so that is a session is added or dropped we do not need to also add to the title or description change tab