### PR TITLE
PLAN-707 add external to pubs table (2.1.0)

### DIFF
--- a/app/controllers/publication_dates_controller.rb
+++ b/app/controllers/publication_dates_controller.rb
@@ -30,4 +30,12 @@ class PublicationDatesController < ResourceController
   def paginate
     false
   end
+
+  def allowed_params
+    %i[
+      id
+      lock_version
+      sent_external
+    ]
+  end
 end

--- a/app/javascript/schedule/schedule_settings.vue
+++ b/app/javascript/schedule/schedule_settings.vue
@@ -12,7 +12,7 @@
           <span class="small text-muted" id="firm-schedule-date" v-if="localFirmSchedule">{{firmScheduledAtText}}</span>
         </b-form-group>
         <div v-if="currentSettings.env !== 'production'">
-          <b-button variant="primary" @click="reset()">Reset for Testing</b-button>
+          <b-button variant="danger" @click="reset()">Reset for Testing</b-button>
           <span>THIS DELETES THE SNAPSHOT AND YOU CAN'T EVER GET IT BACK</span>
         </div>
       </div>
@@ -23,10 +23,10 @@
         <b-table-simple borderless fixed small style="width: 35rem;">
           <b-thead>
             <b-tr>
-              <b-td class="text-center">
+              <b-td colspan="3" class="text-center">
                 <b-button variant="primary" size="sm" :disabled="!canDiff" @click="diff">Show difference</b-button>
               </b-td>
-              <b-td colspan="3" class="text-right">
+              <b-td colspan="13" class="text-right">
                 <icon-button icon="arrow-repeat" class="mr-2" @click="fetchPublicationDates()"></icon-button>
                 <b-button variant="primary" size="sm" v-b-modal.confirm-publish>Create a publish snapshot</b-button>
               </b-td>
@@ -34,7 +34,7 @@
           </b-thead>
         </b-table-simple>
         <b-table
-          :fields="[{key: 'select_2', tdClass: 'text-center', thClass: 'text-center' }, {key: 'timestamp', tdClass: 'text-right', thClass: 'text-right', thAttr: {'colspan': 2}, tdAttr: {'colspan': 2}}]" 
+          :fields="[{key: 'select_2', tdClass: 'text-center', thClass: 'text-center',  thAttr: {'colspan': 3}, tdAttr: {'colspan': 3} }, {key: 'timestamp', tdClass: 'text-right', thClass: 'text-right', thAttr: {'colspan': 10}, tdAttr: {'colspan': 10}}, {key: 'sent_external', tdClass: 'text-center', thClass: 'text-center', thAttr: {'colspan': 3}, tdAttr: {'colspan': 3}, label: 'External'}]" 
           bordered
           fixed
           small
@@ -51,9 +51,16 @@
           <template #cell(select_2)="{ index }">
             <b-form-checkbox name="pubs-diff" v-model="pubsDiff[index]" :disabled="pubsDiffCount >= 2 && !pubsDiff[index]"></b-form-checkbox>
           </template>
+          <template #cell(timestamp)="{ item, index }">
+            <div v-if="!index">{{item.timestamp}}</div>
+            <div v-b-tooltip.html.right="`New Sessions: ${item.new_sessions}<br />Dropped Sessions: ${item.dropped_sessions}<br />Updated Sessions: ${item.updated_sessions}<br />New Assignments: ${item.new_assignments}<br />Dropped Assignments: ${item.dropped_assignments}<br />Updated Assignments: ${item.updated_assignments}`" v-if="index">{{item.timestamp}}</div>
+          </template>
+          <template #cell(sent_external)="{ index, item }">
+            <b-form-checkbox switch v-if="index" v-model="item.sent_external"></b-form-checkbox>
+          </template>
         </b-table>
         <div v-if="currentSettings.env !== 'production'">
-          <b-button variant="primary" @click="resetPubs()">Reset Publish for Testing</b-button>
+          <b-button variant="danger" @click="resetPubs()">Reset Publish for Testing</b-button>
           <span>THIS DELETES ALL THE PUBLISHED DATA AND YOU CAN'T EVER GET IT BACK</span>
         </div>
       </div>
@@ -183,7 +190,7 @@ export default {
       this.pubsLoading = true;
       this.$store.dispatch('jv/get', '/publication_date').then((data) => {
         const {_jv, ...filteredData} = data;
-        this.snapshots = Object.values(filteredData).map(s => ({timestamp: s.timestamp, id: s.id}))
+        this.snapshots = Object.values(filteredData);
         this.snapshots.sort((a, b) => DateTime.fromISO(b.timestamp) - DateTime.fromISO(a.timestamp));
         this.pubsDiff = [false, ...Object.keys(filteredData).map(s => false)];
         this.pubsLoading = false;

--- a/app/javascript/store/model.mixin.js
+++ b/app/javascript/store/model.mixin.js
@@ -45,13 +45,16 @@ export const modelMixinNoProp = {
       return this.toastPromise(this.$store.dispatch(SAVE, {model: this.model, item: this.selected}), MODEL_SAVE_SUCCESS(this.model), MODEL_SAVE_ERROR(this.model));
     },
     patchSelected(data, selected = false, success_text = undefined, error_text = undefined) {
+      return this.patch(this.selected, data, selected, success_text, error_text);
+    },
+    patch(instance, data, selected = false, success_text = undefined, error_text = undefined) {
       if (!success_text) {
         success_text = MODEL_SAVE_SUCCESS(this.model)
       }
       if (!error_text) {
         error_text = MODEL_SAVE_ERROR(this.model)
       }
-      return this.toastPromise(this.$store.dispatch(PATCH_FIELDS, {model: this.model, item: {...this.selected, ...data}, fields: Object.keys(data), selected}), success_text, error_text);
+      return this.toastPromise(this.$store.dispatch(PATCH_FIELDS, {model: this.model, item: {...instance, ...data}, fields: Object.keys(data), selected}), success_text, error_text);
     },
     // need a save instance
     save(instance) {

--- a/app/javascript/store/model.store.js
+++ b/app/javascript/store/model.store.js
@@ -83,6 +83,9 @@ import { appStore } from './app.store';
 import { scheduleWorkflowStore, scheduleWorkflowEndpoints } from './schedule_workflow/schedule_workflow.store';
 import { personScheduleApprovalStore, personScheduleApprovalEndpoints } from './person_schedule_approval/person_schedule_approval.store';
 
+// publication dates
+import { publicationDatesEndpoints, publicationDatesStore } from './publication_dates.store';
+
 import merge from 'lodash.merge'
 
 const endpoints = {
@@ -106,6 +109,7 @@ const endpoints = {
   // ...personExclusionEndpoints,
   ...scheduleWorkflowEndpoints,
   ...personScheduleApprovalEndpoints,
+  ...publicationDatesEndpoints,
 }
 
 // NOTE: this is really the store
@@ -142,6 +146,7 @@ export const store = new Vuex.Store({
       ...sessionConflictStore.selected,
       ...formatStore.selected,
       ...personScheduleApprovalStore.selected,
+      ...publicationDatesStore.selected,
     },
     ...personSessionStore.state,
     ...settingsStore.state,

--- a/app/javascript/store/publication_dates.store.js
+++ b/app/javascript/store/publication_dates.store.js
@@ -1,0 +1,11 @@
+export const publicationDatesModel = 'publication_date'
+
+export const publicationDatesEndpoints = {
+  [publicationDatesModel]: 'publication_date'
+}
+
+export const publicationDatesStore = {
+  selected: {
+    [publicationDatesModel]: undefined
+  }
+}

--- a/app/serializers/publication_date_serializer.rb
+++ b/app/serializers/publication_date_serializer.rb
@@ -4,5 +4,5 @@ class PublicationDateSerializer
   attributes :id, :created_at, :updated_at, :timestamp,
              :new_sessions, :updated_sessions, :dropped_sessions,
              :new_assignments, :updated_assignments, :dropped_assignments,
-             :sent_external
+             :sent_external, :lock_version
 end

--- a/app/serializers/publication_date_serializer.rb
+++ b/app/serializers/publication_date_serializer.rb
@@ -3,5 +3,6 @@ class PublicationDateSerializer
 
   attributes :id, :created_at, :updated_at, :timestamp,
              :new_sessions, :updated_sessions, :dropped_sessions,
-             :new_assignments, :updated_assignments, :dropped_assignments  
+             :new_assignments, :updated_assignments, :dropped_assignments,
+             :sent_external
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
 
   get 'report/schedule_reports/schedule_diff(/:from)(/:to)', to: 'reports/schedule_reports#schedule_diff'
   get 'publication_date/reset', to: 'publication_dates#reset'
-  resources :publication_dates, path: 'publication_date', only: [:index]
+  resources :publication_dates, path: 'publication_date', only: [:index, :update]
 
   resources :availabilities, path: 'availability', except: [:index]
   resources :person_exclusions, path: 'person_exclusion', except: [:index]

--- a/db/migrate/20220818022629_add_sent_external_to_publication_dates.rb
+++ b/db/migrate/20220818022629_add_sent_external_to_publication_dates.rb
@@ -1,5 +1,6 @@
 class AddSentExternalToPublicationDates < ActiveRecord::Migration[6.1]
   def change
     add_column :publication_dates, :sent_external, :boolean, default: false, null: false
+    add_column :publication_dates, :lock_version, :integer, default: 0
   end
 end

--- a/db/migrate/20220818022629_add_sent_external_to_publication_dates.rb
+++ b/db/migrate/20220818022629_add_sent_external_to_publication_dates.rb
@@ -1,0 +1,5 @@
+class AddSentExternalToPublicationDates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :publication_dates, :sent_external, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1351,7 +1351,8 @@ CREATE TABLE public.publication_dates (
     dropped_sessions integer DEFAULT 0,
     new_assignments integer DEFAULT 0,
     updated_assignments integer DEFAULT 0,
-    dropped_assignments integer DEFAULT 0
+    dropped_assignments integer DEFAULT 0,
+    sent_external boolean DEFAULT false NOT NULL
 );
 
 
@@ -3373,6 +3374,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220726130346'),
 ('20220801152151'),
 ('20220801173704'),
-('20220801195644');
+('20220801195644'),
+('20220818022629');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1352,7 +1352,8 @@ CREATE TABLE public.publication_dates (
     new_assignments integer DEFAULT 0,
     updated_assignments integer DEFAULT 0,
     dropped_assignments integer DEFAULT 0,
-    sent_external boolean DEFAULT false NOT NULL
+    sent_external boolean DEFAULT false NOT NULL,
+    lock_version integer DEFAULT 0
 );
 
 


### PR DESCRIPTION
- new field sent_external on publication_dates
- also added a missing lock_version
- endpoints, store, and works with the model mixin
- added a patch to model mixin (and refactored patch selected to use it)
- made the data fetch reactive
- as a bonus: made reset buttons BRIGHT RED
<img width="819" alt="image" src="https://user-images.githubusercontent.com/634425/185398398-a887887e-12d4-4644-a886-408868c9eea7.png">
