### PR TITLE
PLAN-774 PLAN-524 Configure convention settings

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -26,6 +26,8 @@ class SettingsController < ApplicationController
       zones[zone.tzinfo.canonical_zone.name] = "(UTC#{zone.at(con_time).formatted_offset}) #{zone.name}"
     end
 
+    convention_name = ConfigService.value('convention_name')
+
     settings = {
       #
       env: Rails.env,
@@ -61,14 +63,14 @@ class SettingsController < ApplicationController
       attendance_type: [
         {
           value: 'in person',
-          label: '**In-person only:** I am planning to attend Chicon 8 in-person'
+          label: "**In-person only:** I am planning to attend #{convention_name} in-person"
         }, {
           value: 'virtual',
-          label: '**Virtual only:** I am not planning to attend Chicon 8 in-person, and would like to be a virtual participant on virtual-based items only (via Zoom or similar technology).'
+          label: "**Virtual only:** I am not planning to attend #{convention_name} in-person, and would like to be a virtual participant on virtual-based items only (via Zoom or similar technology)."
         },
         {
           value: 'hybrid',
-          label: '**In-person and virtual:** I am planning to attend Chicon 8 in-person, but would also like to be considered for virtual panels.'
+          label: "**In-person and virtual:** I am planning to attend #{convention_name} in-person, but would also like to be considered for virtual panels."
         },
       ],
       age_restrictions: ::AgeRestriction.all,

--- a/app/javascript/administration/privacy_policy_link.vue
+++ b/app/javascript/administration/privacy_policy_link.vue
@@ -1,9 +1,19 @@
 <template>
-    <a href="https://chicagoworldcon.github.io/planorama/privacy" target="_blank">Data Privacy &amp; Protection Policy</a>
+    <a :href="privacyPolicyLink" target="_blank">Data Privacy &amp; Protection Policy</a>
 </template>
 
 <script>
+import settingsMixin from '@/store/settings.mixin'
+
 export default {
-    name: "PrivacyPolicyLink"
+    name: "PrivacyPolicyLink",
+    mixins: [
+        settingsMixin
+    ],
+    computed: {
+        privacyPolicyLink() {
+            return this.configByName('privacy_policy_link') || "https://chicagoworldcon.github.io/planorama/privacy" 
+        }
+    }
 }
 </script>

--- a/app/javascript/administration/terms_of_use_link.vue
+++ b/app/javascript/administration/terms_of_use_link.vue
@@ -1,9 +1,19 @@
 <template>
-    <a href="https://chicagoworldcon.github.io/planorama/tandc" target="_blank">Terms of Use</a>
+    <a :href="termsOfUseLink" target="_blank">Terms of Use</a>
 </template>
 
 <script>
+import { settingsMixin } from '@/mixins';
+
 export default {
-    name: "TermsOfUseLink"
+    name: "TermsOfUseLink",
+    mixins: [
+        settingsMixin
+    ],
+    computed: {
+        termsOfUseLink() {
+            return this.configByName('terms_of_use_link') || "https://chicagoworldcon.github.io/planorama/tandc"; 
+        }
+    }
 }
 </script>

--- a/app/javascript/constants/config.js
+++ b/app/javascript/constants/config.js
@@ -1,2 +1,2 @@
 // TODO gail move this later to somewhere actually obvious
-export const errorEmail = "planorama@chicon.org"
+export const errorEmail = "program@arisia.org"

--- a/app/javascript/constants/config.js
+++ b/app/javascript/constants/config.js
@@ -1,2 +1,2 @@
 // TODO gail move this later to somewhere actually obvious
-export const errorEmail = "program@arisia.org"
+export const errorEmail = "planorama@chicon.org"

--- a/app/javascript/constants/strings.js
+++ b/app/javascript/constants/strings.js
@@ -19,7 +19,7 @@ module.exports = {
     LOGIN_PASSWORD_RESET_EMAIL_SEND: "If an account with the address you specified exists you will receive an email with a password reset link.",
     LOGIN_PASSWORD_CHANGED: "You successfully changed your password.",
     LOGIN_TOKEN_EXPIRED: (resetPasswordLink) => `The password reset link you used is no longer valid. Please request another link here: ${resetPasswordLink}`,
-    LOGIN_CLICK_TO_AGREE: "By clicking ‘Log In’ below, I agree to Chicon 8 storing and using my personal data as documented in the",
+    LOGIN_CLICK_TO_AGREE: (conventionName) => `By clicking ‘Log In’ below, I agree to ${conventionName} storing and using my personal data as documented in the`,
 
     // toast titles
     ERROR_TOAST_TITLE: "Error",

--- a/app/javascript/login/login.vue
+++ b/app/javascript/login/login.vue
@@ -52,13 +52,13 @@ import {
   LOGIN_CLICK_TO_AGREE,
   IEA_FAILURE_TO_SIGN
 } from "@/constants/strings";
+import { settingsMixin } from "@/mixins";
 
 
 export default {
   name: "PlanLogin",
   data() {
     return {
-      LOGIN_CLICK_TO_AGREE,
       person: {
         email: "",
         password: "",
@@ -89,7 +89,15 @@ export default {
     PrivacyPolicyLink,
     IeaModal,
   },
-  mixins: [authMixin, personSessionMixin],
+  mixins: [authMixin, personSessionMixin, settingsMixin],
+  computed: {
+    conventionName() {
+      return this.configByName('convention_name') || ''
+    },
+    LOGIN_CLICK_TO_AGREE() {
+      return LOGIN_CLICK_TO_AGREE(this.conventionName);
+    }
+  },
   mounted: function () {
     if (this.$route.query.alert) {
       switch (this.$route.query.alert) {

--- a/app/javascript/surveys/question.mixin.js
+++ b/app/javascript/surveys/question.mixin.js
@@ -126,19 +126,19 @@ export const questionMixin = {
     },
     inPersonLabel() {
       return this.currentSettings?.attendance_type?.find(at => at.value === "in_person") || {
-        label: "**In-person only:** I am planning to attend Chicon 8 in-person",
+        label: "**In-person only:** I am planning to attend in-person",
         value: "in_person"
       }
     },
     virtualLabel() {
       return this.currentSettings?.attendance_type?.find(at => at.value === "virtual") || {
-        label: "**Virtual only:** I am not planning to attend Chicon 8 in-person, and would like to be a virtual participant on virtual-based items only (via Zoom or similar technology).",
+        label: "**Virtual only:** I am not planning to attend in-person, and would like to be a virtual participant on virtual-based items only (via Zoom or similar technology).",
         value: "virtual",
       };
     },
     hybridLabel() {
       return this.currentSettings?.attendance_type?.find(at => at.value === "hybrid") || {
-        label: "**In-person and virtual:** I am planning to attend Chicon 8 in-person, but would also like to be considered for virtual panels.",
+        label: "**In-person and virtual:** I am planning to attend in-person, but would also like to be considered for virtual panels.",
         value: "hybrid"
       }
     }

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,6 +3,8 @@
 # stored in the DB
 #
 class ApplicationMailer < ActionMailer::Base
+  before_action :convention_name
+
   default from: Proc.new { from_email },
           reply_to: Proc.new { reply_to_email }
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -17,4 +17,8 @@ class ApplicationMailer < ActionMailer::Base
   def reply_to_email
     @reply_to_email = ConfigService.value('email_reply_to_address') || ENV['PROGRAM_EMAIL'] || ENV['SMTP_USER_NAME']
   end
+
+  def convention_name 
+    @convention_name = ConfigService.value('convention_name') || ENV['CONVENTION_NAME']
+  end
 end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,6 +1,6 @@
 <p>Welcome <%= @email %>!</p>
 
-<p>You can confirm your account email for Chicon Planorama through the link below:</p>
+<p>You can confirm your account email for <%= @convention_name %> Planorama through the link below:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
 

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,9 +1,9 @@
 <p>Hello <%= @email %>!</p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %> for Chicon Planorama.</p>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %> for <%= @convention_name %> Planorama.</p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %> for Chicon Planorama.</p>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %> for <%= @convention_name %> Planorama.</p>
 <% end %>
 
 <% if !Rails.env.production? %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,9 +1,9 @@
 <p>Hello <%= @resource.name %>!</p>
 
-<p>Your Planorama password was changed on <%= @resource.updated_at.strftime("%m/%d/%Y at %I:%M%p UTC") %>. If you made this change, you may ignore this message. However, if you did not request a password change, please contact us at program@chicon.org. </p>
+<p>Your Planorama password was changed on <%= @resource.updated_at.strftime("%m/%d/%Y at %I:%M%p UTC") %>. If you made this change, you may ignore this message. However, if you did not request a password change, please contact us at <%= @reply_to_email %>. </p>
 
 <p>Thank you!</p>
-<p>The Planorama Team</p>
+<p>The <%= @convention_name %> Planorama Team</p>
   
 
 <% if !Rails.env.production? %>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,6 +1,6 @@
 <p>Hello <%= @resource.name %>!</p>
 
-<p>You, or someone on your behalf, has requested to change your password for Chicon Planorama. You can do this by clicking the link below.</p>
+<p>You, or someone on your behalf, has requested to change your password for <%= convention_name %> Planorama. You can do this by clicking the link below.</p>
 
 <p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 
@@ -10,7 +10,7 @@
 <p>Your password won't change until you access the link above and create a new password.</p>
 
 <p>Sincerely,</p>
-<p>The Planorama Team</p>
+<p>The <%= @convention_name %> Planorama Team</p>
 
 <% if !Rails.env.production? %>
   <p><b>Brought to you by <%= Rails.env%></b></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,6 +1,6 @@
 <p>Hello <%= @resource.name %>!</p>
 
-<p>You, or someone on your behalf, has requested to change your password for <%= convention_name %> Planorama. You can do this by clicking the link below.</p>
+<p>You, or someone on your behalf, has requested to change your password for <%= @convention_name %> Planorama. You can do this by clicking the link below.</p>
 
 <p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,6 +1,6 @@
 <p>Hello <%= @resource.email %>!</p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts on Chicon Planorama.</p>
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts on <%= @convention_name %> Planorama.</p>
 
 <p>Click the link below to unlock your account:</p>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -32,7 +32,7 @@ Devise.setup do |config|
   config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'ApplicationMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/lib/tasks/parameters.rake
+++ b/lib/tasks/parameters.rake
@@ -77,5 +77,15 @@ namespace :parameters do
         }
       )
     end
+
+    unless ParameterName.find_by(parameter_name: 'convention_name')
+      ParameterName.create!(
+        {
+          parameter_name: 'convention_name',
+          parameter_description: 'The name of the convetion',
+          parameter_type: 'String'
+        }
+      )
+    end
   end
 end

--- a/lib/tasks/parameters.rake
+++ b/lib/tasks/parameters.rake
@@ -87,5 +87,25 @@ namespace :parameters do
         }
       )
     end
+
+    unless ParameterName.find_by(parameter_name: 'privacy_policy_link')
+      ParameterName.create!(
+        {
+          parameter_name: 'privacy_policy_link',
+          parameter_description: 'A link to the privacy policy for this convention',
+          parameter_type: 'String'
+        }
+      )
+    end
+
+    unless ParameterName.find_by(parameter_name: 'terms_of_use_link')
+      ParameterName.create!(
+        {
+          parameter_name: 'terms_of_use_link',
+          parameter_description: 'A link to the planorama terms of use for this convention',
+          parameter_type: 'String'
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
Add the ability to configure the convention name, and the Terms of Use and Privacy Policy links that appear in the footer.

<img width="496" alt="image" src="https://user-images.githubusercontent.com/634425/192156623-3c1cb505-5c04-47cb-b0d2-fdea5b1beb4a.png">

<img width="847" alt="image" src="https://user-images.githubusercontent.com/634425/192156650-083eb031-ac46-4f41-8919-9f31d0147847.png">
