### PR TITLE
PLAN-776 disable display of virtual participant settings

### DIFF
--- a/app/javascript/airmeet/airmeet_settings.vue
+++ b/app/javascript/airmeet/airmeet_settings.vue
@@ -3,6 +3,9 @@
     <div class="row">
       <div class="column">
         <h4 class="mt-3">Configuration</h4>
+        <b-form-group label-cols="auto" label="Enable Airmeet" class="configuration enable">
+          <b-form-checkbox switch v-model="airmeet_enabled" @change="patchAirmeetConfig()"></b-form-checkbox>
+        </b-form-group>
         <b-form-group label="Airmeet ID">
           <b-form-input type="text" v-model="airmeet_id" @blur="patchAirmeetConfig()"></b-form-input>
         </b-form-group>
@@ -74,6 +77,16 @@ export default {
           this.airmeet.config.airmeet_host = val;
         }
       }
+    },
+    airmeet_enabled: {
+      get() {
+        return this.airmeet?.config?.enabled
+      },
+      set(val) {
+        if(this.airmeet?.config) {
+          this.airmeet.config.enabled = val;
+        }
+      }
     }
   },
   methods: {
@@ -109,6 +122,8 @@ export default {
 }
 </script>
 
-<style>
-
+<style lang="scss">
+.configuration.enable .form-row {
+  align-items: center;
+}
 </style>

--- a/app/javascript/configurations/config_editor.vue
+++ b/app/javascript/configurations/config_editor.vue
@@ -8,17 +8,20 @@
     <b-form-group :label="parameter.parameter_name">
       <!-- TODO: We need more meaningful names, ^^^ change the label  -->
       <!-- TODO: we need to change the editor type depending on the parameter.type -->
-      <div v-if="parameter.parameter_type == 'Timezone'">
+      <div v-if="parameter.parameter_type === 'Timezone'">
         <timezone-selector
           v-model="configuration.parameter_value"
           @input="onChange"
         ></timezone-selector>
       </div>
-      <div v-else-if="parameter.parameter_type == 'DateTime'">
+      <div v-else-if="parameter.parameter_type === 'DateTime'">
         <b-form-datepicker
           v-model="dateval"
           @input="onChange"
         ></b-form-datepicker>
+      </div>
+      <div v-else-if="parameter.parameter_type === 'Boolean'">
+        <b-radio-group :options="[{text: 'Yes', value: 'true'}, {text: 'No', value: 'false'}]" @input="onChange" v-model="configuration.parameter_value"></b-radio-group>
       </div>
       <div v-else>
         <b-form-input

--- a/app/javascript/configurations/config_editor.vue
+++ b/app/javascript/configurations/config_editor.vue
@@ -5,7 +5,7 @@
     :skipIfEmpty="true"
     v-slot="{ valid, errors }"
   >
-    <b-form-group :label="parameter.parameter_name">
+    <b-form-group :label="parameterLabel">
       <!-- TODO: We need more meaningful names, ^^^ change the label  -->
       <!-- TODO: we need to change the editor type depending on the parameter.type -->
       <div v-if="parameter.parameter_type === 'Timezone'">
@@ -41,6 +41,7 @@ import configurationMixin from './configuration.mixin';
 import { ValidationProvider } from 'vee-validate';
 import TimezoneSelector from "../components/timezone_selector.vue"
 import settingsMixin from "@/store/settings.mixin";
+import {startCase} from "lodash";
 
 const { DateTime } = require("luxon");
 
@@ -77,6 +78,12 @@ export default {
     },
     timezone() {
       return this.configByName('convention_timezone')
+    },
+    parameterLabel() {
+      if (this.parameter.parameter_name) {
+        return startCase(this.parameter.parameter_name)
+      }
+      return ''
     }
   },
   mixins: [

--- a/app/javascript/dashboard/dashboard.vue
+++ b/app/javascript/dashboard/dashboard.vue
@@ -19,7 +19,7 @@
               <li>
                 Update your name(s), pronouns, email address, bio, and social media as needed
               </li>
-              <li>
+              <li v-if="eventVirtual">
                 If you’re not going to be attending the convention in-person, please let us know the timezone that you will be in when you attend virtually.
               </li>
             </ul>
@@ -57,7 +57,7 @@
               <li>
                 Select sessions by using the slider to the right of the description. Your selections will save automatically.
               </li>
-              <li>
+              <li v-if="eventVirtual">
                 While some items are marked or otherwise described as Virtual, many we’re not sure if they will be taking place in-person or online, so everyone should feel free to sign up for items not marked either way.
               </li>
             </ul>
@@ -113,14 +113,15 @@
 </template>
 
 <script>
-import { personSessionMixin, toastMixin } from '@/mixins';
+import { personSessionMixin, toastMixin} from '@/mixins';
 import { mapActions } from 'vuex'; 
 import { FETCH_WORKFLOWS, scheduleWorkflowMixin } from '@/store/schedule_workflow';
 import PersonScheduleDisplay from '@/profile/person_schedule_display.vue';
+import { eventVirtualMixin } from '@/shared/event-virtual.mixin';
 
 export default {
   name: "Dashboard",
-  mixins: [personSessionMixin, toastMixin, scheduleWorkflowMixin],
+  mixins: [personSessionMixin, toastMixin, scheduleWorkflowMixin, eventVirtualMixin],
   components: {
     PersonScheduleDisplay
   },

--- a/app/javascript/integrations/airmeet.mixin.js
+++ b/app/javascript/integrations/airmeet.mixin.js
@@ -1,0 +1,22 @@
+import { FETCH_AIRMEET_INTEGRATION } from "@/store/integration.store";
+import { mapActions, mapGetters, mapState } from "vuex";
+
+export const airmeetMixin = {
+  methods:{
+    ...mapActions({
+      fetchAirmeetInfo: FETCH_AIRMEET_INTEGRATION
+    }),
+    fetchAirmeetInfoIfMissing() {
+      if (!this.airmeet || !Object.keys(this.airmeet).length) {
+        this.fetchAirmeetInfo();
+      }
+    }
+  },
+  computed: {
+    ...mapGetters(['airmeetEnabled']),
+    ...mapState(['airmeet']),
+  },
+  mounted() {
+    this.fetchAirmeetInfoIfMissing();
+  }
+}

--- a/app/javascript/profile/availability_and_interests.vue
+++ b/app/javascript/profile/availability_and_interests.vue
@@ -12,9 +12,11 @@
           </session-limit-editor>
         <p>
           Under each day, highlight (click and drag) the times of day that you are available for programming in the calendar view below.
-          You can create multiple blocks of time per day. The in-person convention time is currently displayed,
+          You can create multiple blocks of time per day. <span v-if="eventVirtual" >The in-person convention time is currently displayed,
           and is Central Daylight Time (UTC-5). If you will be attending virtually,
           and want to enter your availability in that time zone, select that option from below the calendar.
+          </span>
+          <span v-if="!eventVirtual">The time is displayed in the convention time zone, which is currently {{timezone}}.</span>
         </p>
       </div>
     </div>
@@ -27,7 +29,7 @@
           :timezone="calTimeZone"
         ></availability-calendar>
         <!-- NOTE: The timezone selection for availability affects calendar AND limit display. -->
-        <div class="mt-1 w-50">
+        <div class="mt-1 w-50" v-if="eventVirtual">
           Select time zone to work in:
           <b-form-select v-model="calTimeZone" :options="timeZoneOptions"></b-form-select>
         </div>
@@ -75,13 +77,15 @@ import SessionLimitEditor from './session_limit_editor.vue'
 import AvailabilityNotesField from './availability_notes_field';
 import TimezoneSelector from "../components/timezone_selector.vue"
 import searchStateMixin from "@/store/search_state.mixin"
+import { eventVirtualMixin } from '@/shared/event-virtual.mixin';
 
 const { DateTime } = require("luxon");
 
 export default {
   name: "AvailabilityAndInterests",
   mixins: [
-    searchStateMixin
+    searchStateMixin,
+    eventVirtualMixin
   ],
   components: {
     SessionLimitEditor,
@@ -159,7 +163,7 @@ export default {
         start_day = start_day.plus({days: 1})
       }
       return res
-    }
+    },
   },
   methods: {
     onNotePatched(arg) {

--- a/app/javascript/profile/person_details.vue
+++ b/app/javascript/profile/person_details.vue
@@ -15,35 +15,37 @@
       </dl-person>
     </div>
     <div class="d-flex flex-column w-50 p-2">
-      <div><b>I plan to attend the convention:</b></div>
-      <b-form-radio-group
-        v-model="selected.attendance_type"
-        stacked
-        @change="saveSelected()"
-      >
-        <b-form-radio value="in person">In Person</b-form-radio>
-        <b-form-radio value="hybrid">In Person AND Virtually</b-form-radio>
-        <b-form-radio value="virtual">Virtually</b-form-radio>
-      </b-form-radio-group>
-      <b-form-group label="At the time of the convention I will be at UTC Offset">
-        <timezone-selector
-          v-model="selected.timezone"
-          @input="saveSelected()"
-          class="mb-2"
-          :disabled="disabled || selected.attendance_type != 'virtual'"
-        ></timezone-selector>
-        <p>
-          Your time now in the selected timezone is <b>{{youTimeNow}}</b>
-        </p>
-        <small>
-          If you are not sure what your UTC offset will be, or want to verify,
-          please go to
-          <a target="blank" href="https://www.timeanddate.com/worldclock/meeting.html">
-            https://www.timeanddate.com/worldclock/meeting.html
-          </a>
-          and check by specifying the date of September 1 2022 and your location as well as UTC/GMT
-        </small>
-      </b-form-group>
+      <div v-if="eventVirtual">
+        <div><b>I plan to attend the convention:</b></div>
+        <b-form-radio-group
+          v-model="selected.attendance_type"
+          stacked
+          @change="saveSelected()"
+        >
+          <b-form-radio value="in person">In Person</b-form-radio>
+          <b-form-radio value="hybrid">In Person AND Virtually</b-form-radio>
+          <b-form-radio value="virtual">Virtually</b-form-radio>
+        </b-form-radio-group>
+        <b-form-group label="At the time of the convention I will be at UTC Offset">
+          <timezone-selector
+            v-model="selected.timezone"
+            @input="saveSelected()"
+            class="mb-2"
+            :disabled="disabled || selected.attendance_type != 'virtual'"
+          ></timezone-selector>
+          <p>
+            Your time now in the selected timezone is <b>{{youTimeNow}}</b>
+          </p>
+          <small>
+            If you are not sure what your UTC offset will be, or want to verify,
+            please go to
+            <a target="blank" href="https://www.timeanddate.com/worldclock/meeting.html">
+              https://www.timeanddate.com/worldclock/meeting.html
+            </a>
+            and check by specifying the date of September 1 2022 and your location as well as UTC/GMT
+          </small>
+        </b-form-group>
+      </div>
       <!-- <b-form-checkbox v-model="selected.twelve_hour" @input="saveSelected()">
         12 Hour Display
       </b-form-checkbox> -->
@@ -219,6 +221,7 @@ import { modelMixinNoProp } from '@/store/model.mixin';
 import { personModel as model } from "@/store/person.store";
 import { DateTime } from "luxon";
 import personSessionMixin from '@/auth/person_session.mixin';
+import { eventVirtualMixin } from '@/shared/event-virtual.mixin';
 
 export default {
   name: "PersonDetails",
@@ -235,7 +238,8 @@ export default {
   mixins: [
     settingsMixin,
     modelMixinNoProp,
-    personSessionMixin
+    personSessionMixin,
+    eventVirtualMixin
   ],
   data: () =>  ({
     disabled: false,

--- a/app/javascript/profile/person_summary.vue
+++ b/app/javascript/profile/person_summary.vue
@@ -15,7 +15,7 @@
         </div>
         <div class="col-4 d-flex flex-column align-items-end">
             <small>Last Login: {{formatLocaleDate(selected.current_sign_in_at)}}</small>
-            <b-button v-if="currentUserIsAdmin" variant="warning" :disabled="!selected.integrations.airmeet" @click="resyncAirmeet" class="mt-2">Airmeet re-sync completed</b-button>
+            <b-button v-if="currentUserIsAdmin && airmeetEnabled" variant="warning" :disabled="!selected.integrations.airmeet" @click="resyncAirmeet" class="mt-2">Airmeet re-sync completed</b-button>
         </div>
       </div>
       <person-edit-modal id="person-top-modal" body-class="formscroll" :person="selected" :data="editData">
@@ -46,6 +46,7 @@ import { modelMixinNoProp } from '@/store/model.mixin';
 import { personEndpoints, personModel } from '@/store/person.store';
 import {PERSON_NEVER_LOGGED_IN} from "@/constants/strings";
 import { toastMixin, personSessionMixin } from '@/mixins';
+import { airmeetMixin } from '@/integrations/airmeet.mixin';
 
 export default {
   name: "PersonSummary",
@@ -66,6 +67,7 @@ export default {
     modelMixinNoProp,
     personSessionMixin,
     toastMixin,
+    airmeetMixin
   ],
   computed: {
     willing_to_moderate() {

--- a/app/javascript/sessions/session_summary.vue
+++ b/app/javascript/sessions/session_summary.vue
@@ -106,7 +106,7 @@
             </b-form-select-option>
           </b-form-select>
         </b-form-group>
-        <b-button v-if="currentUserIsAdmin" variant="warning" :disabled="!session.streamed" @click="resyncAirmeet" class="mt-2">Airmeet re-sync completed</b-button>
+        <b-button v-if="currentUserIsAdmin && airmeetEnabled" variant="warning" :disabled="!session.streamed" @click="resyncAirmeet" class="mt-2">Airmeet re-sync completed</b-button>
       </div>
     </div>
   </div>
@@ -122,6 +122,7 @@ import settingsMixin from "@/store/settings.mixin";
 import PlanoEditor from '../components/plano_editor';
 import { personSessionMixin } from '@/mixins';
 import { publishedSessionEndpoints, publishedSessionModel } from '@/store/published_session.store';
+import { airmeetMixin } from '@/integrations/airmeet.mixin';
 
 export default {
   name: "SessionSummary",
@@ -132,7 +133,8 @@ export default {
     modelUtilsMixin,
     scheduledMixin,
     settingsMixin,
-    personSessionMixin
+    personSessionMixin,
+    airmeetMixin
   ],
   data: () => ({
     SESSION_STATUS,

--- a/app/javascript/shared/event-virtual.mixin.js
+++ b/app/javascript/shared/event-virtual.mixin.js
@@ -1,0 +1,12 @@
+import { settingsMixin } from "@/mixins";
+
+export const eventVirtualMixin = {
+  mixins: [
+    settingsMixin,
+  ],
+  computed: {
+    eventVirtual() {
+      return this.configByName('event_virtual') !== "false"
+    }
+  }
+}

--- a/app/javascript/store/integration.store.js
+++ b/app/javascript/store/integration.store.js
@@ -13,6 +13,11 @@ export const integrationStore = {
   state: {
     airmeet: {}
   },
+  getters: {
+    airmeetEnabled(state) {
+      return state.airmeet?.config?.enabled;
+    }
+  },
   mutations: {
     [SET_AIRMEET_INTEGRATION] (state, integration) {
       state.airmeet = integration;

--- a/app/javascript/store/model.store.js
+++ b/app/javascript/store/model.store.js
@@ -203,6 +203,7 @@ export const store = new Vuex.Store({
     ...settingsStore.getters,
     ...formatStore.getters,
     ...scheduleWorkflowStore.getters,
+    ...integrationStore.getters,
   },
   plugins: [
     ...surveyStore.plugins

--- a/app/serializers/integration_serializer.rb
+++ b/app/serializers/integration_serializer.rb
@@ -6,10 +6,8 @@ class IntegrationSerializer
 
   attribute :config do |integration|
     {airmeet_id: integration.config["airmeet_id"],
-      airmeet_host: integration.config["airmeet_host"]
+      airmeet_host: integration.config["airmeet_host"],
+      enabled: integration.config["enabled"]
     }
   end
-
-  
-             
 end

--- a/lib/tasks/parameters.rake
+++ b/lib/tasks/parameters.rake
@@ -107,5 +107,15 @@ namespace :parameters do
         }
       )
     end
+
+    unless ParameterName.find_by(parameter_name: 'event_virtual')
+      ParameterName.create!(
+        {
+          parameter_name: 'event_virtual',
+          parameter_description: 'This should be true if your event is virtual or hybrid',
+          parameter_type: 'Boolean'
+        }
+      )
+    end
   end
 end

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "follow-redirects": "^1.14.0",
     "jquery": "^3.6.0",
     "jsonapi-vuex": "^4.5",
+    "lodash": "^4.17.21",
     "luxon": "^2.3.1",
     "mitt": "^2.1.0",
     "nth-check": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5942,7 +5942,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.7.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
there are two new toggles that hide things:
- event_virtual which controls the showing and hiding of all participant-facing virtual information
- airmeet enabled is now honored and configurable. it controls the display of the airmeet sync buttons

<img width="799" alt="image" src="https://user-images.githubusercontent.com/634425/192159516-c135825e-cc33-4a94-900b-0ee7c22bbfa2.png">
<img width="790" alt="image" src="https://user-images.githubusercontent.com/634425/192159530-79adc918-9d79-4896-91fb-4e7d60cd901b.png">

<img width="813" alt="image" src="https://user-images.githubusercontent.com/634425/192159563-7777ece3-fdf8-4a6e-98eb-414b6683dd65.png">
<img width="335" alt="image" src="https://user-images.githubusercontent.com/634425/192159596-085199d4-1128-473b-954a-f830194b28a2.png">
<img width="798" alt="image" src="https://user-images.githubusercontent.com/634425/192159764-4a236c7f-5c06-45e8-bf0a-04c9855f6921.png">
<img width="814" alt="image" src="https://user-images.githubusercontent.com/634425/192159903-78d14036-1c56-48a1-96ae-0086feb52515.png">

