### PR TITLE
PLAN-811 style fixes

### DIFF
--- a/app/javascript/components/edit_button.vue
+++ b/app/javascript/components/edit_button.vue
@@ -9,7 +9,7 @@ export default {
   name: "EditButton",
   props: {
     title: {
-      default: "Edit Button"
+      default: "Edit"
     }
   },
   components: {

--- a/app/javascript/profile/dl_person.vue
+++ b/app/javascript/profile/dl_person.vue
@@ -6,13 +6,13 @@
             {{PROFILE_FIELD_LABELS[field]}}
           </slot>
         </dt>
-        <dd :key="'dd-' + i" class="ml-2">
+        <dd :key="'dd-' + i" class="ml-2 font-italic">
           <slot :name="field + '-val'" :value="selected[field]">
-            <span v-if="selected[field] === undefined" class="text-muted font-italic">Restricted</span>
-            <span v-else-if="selected[field] === true" class="font-italic">Yes</span>
-            <span v-else-if="selected[field] === false" class="font-italic">No</span>
-            <span v-else-if="selected[field] === null || selected[field].trim().length === 0" class="text-muted font-italic">Not Specified</span>
-            <span v-else class="keep-format font-italic">{{selected[field]}}</span>
+            <span v-if="selected[field] === undefined" class="text-muted">Restricted</span>
+            <span v-else-if="selected[field] === true">Yes</span>
+            <span v-else-if="selected[field] === false">No</span>
+            <span v-else-if="selected[field] === null || selected[field].trim().length === 0" class="text-muted">Not Specified</span>
+            <span v-else class="keep-format">{{selected[field]}}</span>
           </slot>
         </dd>
     </template>

--- a/app/javascript/profile/person_details.vue
+++ b/app/javascript/profile/person_details.vue
@@ -83,7 +83,7 @@
       </template>
     </person-edit-modal>
     <person-edit-modal id="person-misc-modal" :person="selected" :data="miscData" :validate="true">
-      <template #modal-title>Edit Preferences - {{selected.published_name}}</template>
+      <template #modal-title>Edit Additional Info - {{selected.published_name}}</template>
       <template #default="{fields}">
         <validation-provider name="Anyone that should not be assigned with">
           <b-form-group label="Anyone that should not be assigned to be on a panel with participant">

--- a/app/javascript/profile/person_details.vue
+++ b/app/javascript/profile/person_details.vue
@@ -22,7 +22,7 @@
         model='email_address'
         @input="$emit('input', selected)"
       ></email-addresses-editor>
-      <h5>Preferences <edit-button v-b-modal.person-misc-modal v-if="!readOnly"></edit-button></h5>
+      <h5>Additional Information <edit-button v-b-modal.person-misc-modal v-if="!readOnly"></edit-button></h5>
       <dl-person :fields="miscFields">
         <template #can_stream-val>{{can_stream_label}}</template>
         <template #can_record-val>{{can_record_label}}</template>


### PR DESCRIPTION
- name of preferences fields is now "additional information"
- all text now properly italicized

<img width="565" alt="image" src="https://user-images.githubusercontent.com/634425/198854695-b15e13b6-f32d-4cb9-97bb-0005f8ece06c.png">

<img width="606" alt="image" src="https://user-images.githubusercontent.com/634425/198856569-bcfb8d21-bfd5-4e48-9fcb-c92c9cdb9ac2.png">
