### PR TITLE
PLAN-794 - Mailing fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    pg (1.4.3)
+    pg (1.4.4)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)

--- a/app/services/mail_service.rb
+++ b/app/services/mail_service.rb
@@ -94,7 +94,7 @@ module MailService
         mail: mail
       )
     end
-  rescue Net::SMTPSyntaxError
+  rescue Net::SMTPSyntaxError, Net::SMTPAuthenticationError, Net::SMTPFatalError, Net::SMTPUnknownError, Net::SMTPUnsupportedCommand => error
     self.save_mail_history(
       person:       person,
       email_status: MailHistory.email_statuses[:failed],

--- a/app/workers/mailing_worker.rb
+++ b/app/workers/mailing_worker.rb
@@ -5,17 +5,18 @@ class MailingWorker
   def perform(mailing_id, send_test = false, test_address = nil, tester_id = nil)
     mailing = Mailing.find mailing_id
 
-    mailing.with_lock do
-      if send_test
-        send_test_mail(
-          mailing: mailing,
-          test_address: test_address,
-          tester_id: tester_id
-        )
-      else
-        send_mailing(mailing: mailing)
-      end
+    # with lock is a problem ....
+    # mailing.with_lock do
+    if send_test
+      send_test_mail(
+        mailing: mailing,
+        test_address: test_address,
+        tester_id: tester_id
+      )
+    else
+      send_mailing(mailing: mailing)
     end
+    # end
   end
 
   def send_mailing(mailing:)
@@ -36,6 +37,7 @@ class MailingWorker
         )
 
         # note the last person processes so we can continue from there if job stopped and restarted
+        # need to do this as a seperate transaction ...
         mailing.last_person_idx = idx # use a counter
         mailing.save
       rescue => msg

--- a/app/workers/mailing_worker.rb
+++ b/app/workers/mailing_worker.rb
@@ -5,8 +5,7 @@ class MailingWorker
   def perform(mailing_id, send_test = false, test_address = nil, tester_id = nil)
     mailing = Mailing.find mailing_id
 
-    # with lock is a problem ....
-    # mailing.with_lock do
+    # Send the mailing
     if send_test
       send_test_mail(
         mailing: mailing,
@@ -16,11 +15,9 @@ class MailingWorker
     else
       send_mailing(mailing: mailing)
     end
-    # end
   end
 
   def send_mailing(mailing:)
-    # TODO - if test run then send to the requestor
     return unless mailing.mailing_state == Mailing.mailing_states[:submitted] # Check just in case this is a dup
 
     participant_schedule_url = SessionService.participant_schedule_url

--- a/script/planorama_start.sh
+++ b/script/planorama_start.sh
@@ -29,12 +29,12 @@ if [[ -z $RAILS_ENV ]] || [[ $RAILS_ENV = "development" ]]; then
   bin/rake db:migrate
   bin/rake parameters:seed_names
   bin/rake role_types:seed_role_types
-  bin/rake chicon:seed_exclusions
-  bin/rake chicon:seed_room_sets
-  bin/rake chicon:seed_rooms
-  bin/rake chicon:fix_formats
-  bin/rake chicon:init_age_restrictions
-  bin/rake chicon:map_session_to_exclusion
+  # bin/rake chicon:seed_exclusions
+  # bin/rake chicon:seed_room_sets
+  # bin/rake chicon:seed_rooms
+  # bin/rake chicon:fix_formats
+  # bin/rake chicon:init_age_restrictions
+  # bin/rake chicon:map_session_to_exclusion
   bin/rake rbac:seed_defaults
 
   # Run migrations and start the server, anything that comes in on 3000 is accepted
@@ -47,12 +47,12 @@ elif [[ $RAILS_ENV = "staging" ]]; then
   bin/rake db:migrate
   bin/rake parameters:seed_names
   bin/rake role_types:seed_role_types
-  bin/rake chicon:seed_exclusions
-  bin/rake chicon:seed_room_sets
-  bin/rake chicon:seed_rooms
-  bin/rake chicon:fix_formats
-  bin/rake chicon:init_age_restrictions
-  bin/rake chicon:map_session_to_exclusion
+  # bin/rake chicon:seed_exclusions
+  # bin/rake chicon:seed_room_sets
+  # bin/rake chicon:seed_rooms
+  # bin/rake chicon:fix_formats
+  # bin/rake chicon:init_age_restrictions
+  # bin/rake chicon:map_session_to_exclusion
   bin/rake rbac:seed_defaults
 
   bin/rails db:seed
@@ -68,12 +68,12 @@ else
   bin/rake db:migrate
   bin/rake parameters:seed_names
   bin/rake role_types:seed_role_types
-  bin/rake chicon:seed_exclusions
-  bin/rake chicon:seed_room_sets
-  bin/rake chicon:seed_rooms
-  bin/rake chicon:fix_formats
-  bin/rake chicon:init_age_restrictions
-  bin/rake chicon:map_session_to_exclusion
+  # bin/rake chicon:seed_exclusions
+  # bin/rake chicon:seed_room_sets
+  # bin/rake chicon:seed_rooms
+  # bin/rake chicon:fix_formats
+  # bin/rake chicon:init_age_restrictions
+  # bin/rake chicon:map_session_to_exclusion
   bin/rake rbac:seed_defaults
 fi
 


### PR DESCRIPTION
Mailing worker has following changes

- make sure that place of last send is saved so that resume does not resend prior messages (transaction issue)
- add more exceptions to catch
- ensure the fail messages are saved in the mail history and marked as failed (do not stop processing rest of mailing)
