### PR TITLE
Dev: change the docker compose volumes to avoid collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ The dev docker compose uses external volumes so that we can persist data
 between runs. These are created using the following:
 
 ```
-docker volume create --name=pgdata
-docker volume create --name=redis-data
-docker volume create --name=node_modules
-docker volume create --name=node_modules_sidekiq
+docker volume create --name=planorama_pgdata
+docker volume create --name=planorama_redis-data
+docker volume create --name=planorama_node_modules
+docker volume create --name=planorama_node_modules_sidekiq
 ```
 
 Then to start the dev docker instances use
@@ -127,8 +127,8 @@ Now you can delete the volumes. You have to manually recreate them before you ca
 
 ```
 docker volume rm node_modules node_modules_sidekiq
-docker volume create --name=node_modules
-docker volume create --name=node_modules_sidekiq
+docker volume create --name=planorama_node_modules
+docker volume create --name=planorama_node_modules_sidekiq
 ```
 
 Now you can run `docker-compose`
@@ -166,7 +166,7 @@ Redis data needs to be persistent between runs of the docker container. You will
 docker command as follows:
 
 ```
-docker volume create --name=redis-data
+docker volume create --name=planorama_redis-data
 ```
 
 ## Environment

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -4,10 +4,10 @@
 #
 # NOTE:
 # You will need to create volumes for the data to be persistent between runs
-#   docker volume create --name=pgdata
-#   docker volume create --name=redis-data
-#   docker volume create --name=node_modules
-#   docker volume create --name=node_modules_sidekiq
+#   docker volume create --name=planorama_pgdata
+#   docker volume create --name=planorama_redis-data
+#   docker volume create --name=planorama_node_modules
+#   docker volume create --name=planorama_node_modules_sidekiq
 #
 # NOTE:
 # start the docker containers:
@@ -20,13 +20,13 @@
 version: "3.7"
 
 volumes:
-  pgdata:
+  planorama_pgdata:
     external: true
-  redis-data:
+  planorama_redis-data:
     external: true
-  node_modules:
+  planorama_node_modules:
     external: true
-  node_modules_sidekiq:
+  planorama_node_modules_sidekiq:
     external: true
   box: {} # used for the bundler, persistent store between runs
 
@@ -47,7 +47,7 @@ services:
       - SMTP_PORT=1025
       - VITE_RUBY_HOST=0.0.0.0
     volumes:
-      - node_modules:/opt/planorama/node_modules
+      - planorama_node_modules:/opt/planorama/planorama_node_modules
       - .:/opt/planorama
       - box:/var/bundler
       - type: tmpfs
@@ -79,7 +79,7 @@ services:
       - SMTP_PORT=1025
       - VITE_RUBY_HOST=0.0.0.0
     volumes:
-      - node_modules_sidekiq:/opt/planorama/node_modules
+      - planorama_node_modules_sidekiq:/opt/planorama/planorama_node_modules
       - .:/opt/planorama
       - box:/var/bundler
       - type: tmpfs
@@ -100,7 +100,7 @@ services:
     env_file:
       - .envrc
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - planorama_pgdata:/var/lib/postgresql/data
     ports:
       - "5432:5432"
 
@@ -108,7 +108,7 @@ services:
     image: redis:alpine
     restart: always
     volumes:
-      - redis-data:/data
+      - planorama_redis-data:/data
     ports:
       - "6379:6379"
 

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -2,16 +2,16 @@
 # This is sample docker file for use in a staging environment
 #
 # NOTE:
-# You will need to create the pgdata and redis-data volumes:
-#   docker volume create --name=pgdata
-#   docker volume create --name=redis-data
+# You will need to create the planorama_pgdata and planorama_redis-data volumes:
+#   docker volume create --name=planorama_pgdata
+#   docker volume create --name=planorama_redis-data
 #
-version: '3.7'
+version: "3.7"
 
 volumes:
-  redis-data:
+  planorama_redis-data:
     external: true
-  pgdata:
+  planorama_pgdata:
     external: true
 
 services:
@@ -19,7 +19,7 @@ services:
     image: redis:alpine
     restart: always
     volumes:
-      - redis-data:/data
+      - planorama_redis-data:/data
 
   postgres:
     image: postgres:12-alpine
@@ -28,7 +28,7 @@ services:
       # NOTE: this will need to reflect local system
       - "/opt/plano/etc/planorama.env"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - planorama_pgdata:/var/lib/postgresql/data
     ports:
       - "5432:5432"
 


### PR DESCRIPTION
The external docker volumes make development of this application on a shared laptop pretty rough; it uses common volume names with no namespacing.

This adds a `planorama_` prefix to the volumes