### PR TITLE
Changes so we get an AMD image for OS X dev

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,7 +1,8 @@
 # Dockerfile
 
 # Use ruby image to build our own image
-FROM --platform=linux/x86_64 ruby:3.1.4-alpine3.19 as base
+# FROM --platform=linux/x86_64 ruby:3.1.4-alpine3.19 as base
+FROM ruby:3.1.4-alpine3.19 as base
 
 # Ensure that we work in UTF 8
 ENV LANG C.UTF-8 # ensure that the encoding is UTF8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       net-http (>= 0.5.0)
     fast_excel (0.5.0)
       ffi (> 1.9, < 2)
+    ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-musl)
     fugit (1.11.1)
@@ -219,6 +220,8 @@ GEM
       activerecord (>= 4.0.0)
       activesupport (>= 4.0.0)
     nio4r (2.7.4)
+    nokogiri (1.18.8-aarch64-linux-musl)
+      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-musl)
@@ -445,6 +448,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  aarch64-linux-musl
   arm64-darwin-24
   arm64-darwin-25
   x86_64-linux-musl


### PR DESCRIPTION
This will build an image for Plano dev that is suitable for the host dev machine's archirtecture

NOTE: make sure you delete the plano-dev_box volume otherwise you will have a gems from the previous architecture and it will cause issues.