### PR TITLE
Functionality to Fix full total

### DIFF
--- a/app/controllers/concerns/resource_methods.rb
+++ b/app/controllers/concerns/resource_methods.rb
@@ -177,6 +177,13 @@ module ResourceMethods
     per_page = params[:perPage]&.to_i || model_class.default_per_page if paginated && do_paginate
     per_page = nil unless paginated && do_paginate
     current_page = params[:current_page]&.to_i || 1 if paginated && do_paginate
+    default_filter = if params[:default_filter]
+                        if params[:default_filter].kind_of? String
+                          JSON.parse(params[:default_filter]) 
+                        else
+                          params[:default_filter]
+                        end
+                      end
     filters = if params[:filter]
                 if params[:filter].kind_of? String
                   JSON.parse(params[:filter]) 
@@ -185,7 +192,7 @@ module ResourceMethods
                 end
               end
 
-    return per_page, current_page, filters
+    return per_page, current_page, filters, default_filter
   end
 
   def order_string(order_by: nil)
@@ -232,7 +239,7 @@ module ResourceMethods
              model_class
            end
 
-    @per_page, @current_page, @filters = collection_params
+    @per_page, @current_page, @filters, @default_filters = collection_params
 
 
     q = if select_fields
@@ -249,9 +256,9 @@ module ResourceMethods
          .references(references)
          .eager_load(eager_load)
          .joins(join_tables)
+         .where(query(@default_filters))
          .where(query(@filters))
          .where(collection_where)
-        #  anpther where?
 
     q = q.distinct if (join_tables && !join_tables.empty?) || make_distinct?
 

--- a/app/javascript/components/table_vue.vue
+++ b/app/javascript/components/table_vue.vue
@@ -75,6 +75,7 @@
       </div>
     <div class="d-flex mb-1">
       <span v-if="totalRows != fullTotalRows">Search Results: {{totalRows}}</span>
+      <!-- Simplec count caption -->
       <span class="ml-auto">{{countCaption}}</span>
     </div>
     <b-table
@@ -214,6 +215,10 @@ export default {
     showBottomControls: {
       type: Boolean,
       default: true
+    },
+    showFullTotalCaption: {
+      type: Boolean,
+      default: true
     }
   },
   data () {
@@ -233,7 +238,11 @@ export default {
       }
       if (this.totalRows == 0) from = 0 
 
-      return `Showing ${from} to ${to} of ${this.totalRows} (${this.fullTotalRows} total records)`
+      if (this.showFullTotalCaption) {
+        return `Showing ${from} to ${to} of ${this.totalRows} (${this.fullTotalRows} total records)`
+      } else {
+        return `Showing ${from} to ${to} of ${this.totalRows}`
+      }
     },
     useSelectMode() {
       if (this.selectMode == 'multi') {

--- a/app/javascript/mailings/mailings_table.vue
+++ b/app/javascript/mailings/mailings_table.vue
@@ -12,7 +12,6 @@
       :show-refresh="true"
       :show-clone="true"
       :show-view="true"
-      :showFullTotalCaption="false"
       @view="$emit('view')"
       @clone="$emit('clone')"
       ref="mailings-table"

--- a/app/javascript/mailings/mailings_table.vue
+++ b/app/javascript/mailings/mailings_table.vue
@@ -12,6 +12,7 @@
       :show-refresh="true"
       :show-clone="true"
       :show-view="true"
+      :showFullTotalCaption="false"
       @view="$emit('view')"
       @clone="$emit('clone')"
       ref="mailings-table"

--- a/app/javascript/store/table.mixin.js
+++ b/app/javascript/store/table.mixin.js
@@ -93,28 +93,22 @@ export const tableMixin = {
       this.tableBusy = true;
       this.shall_clear = clear
       let _filter = JSON.stringify(this.filter)
+      let _default_filter = null
 
-      if (!this.filter && this.defaultFilter) {
-        _filter = this.defaultFilter
-      }
-
-      // if this.filter AND this.defaultFilter then we merge
-      if (this.filter && this.defaultFilter) {
-        let merged = this.mergeFilters(this.defaultFilter, _filter)
-        _filter = merged
+      if (typeof this.defaultFilter != 'string') {
+        _default_filter = JSON.stringify(this.defaultFilter)
       }
 
       return new Promise((res, rej) => {
         if (clear) this.clear() // NOTE: clear is a sync call
         this.correctOrder = [] // we need to clear otherwise the order in the computed sorted gets weird
-        // What URL does this use
         this.fetch(
           {
-            // THIS IS THE PROBLEM
             perPage: perPage,
             sortOrder: this.sortDesc ? 'desc' : 'asc',
             sortBy: this.sortBy,
             filter: _filter,
+            default_filter: _default_filter,
             current_page: this.currentPage,
             nullsFirst: this.nullsFirst
           },


### PR DESCRIPTION
The table shows ”Showing 21 to 40 of 71 (83 total records)”

Because there are 71 sent mailings + 12 draft. The table only shows the sent mailings (but there are 83 mailing records in the DB because of the drafts)

We have the number of total records in the generic table component to show the total if there were no filters (e.g. in advanced search). So we should suppress it in such cases as these because it is misleading.

Code changed to allow a default filter seperately