### PR TITLE
PLAN-1108 Fix split error for additional info (Profile)

### DIFF
--- a/app/javascript/profile/person_details.vue
+++ b/app/javascript/profile/person_details.vue
@@ -127,7 +127,7 @@
               <b-form-radio :value="maybeLabel.value">{{maybeLabel.label}}</b-form-radio>
             </b-form-radio-group>
           </Field>
-          <Field>
+          <Field name="Can Stream Exceptions">
             <b-textarea v-model="fields.can_stream_exceptions"></b-textarea>
           </Field>
         </b-form-group>


### PR DESCRIPTION
Problem is that vee-validate fields must have a name attribute. This was missing from one of the fields.