### PR TITLE
PLAN-1134 fix the db_missing task to actually check the connection

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2273,15 +2273,6 @@ CREATE TABLE public.tags (
 
 
 --
--- Name: tt; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.tt (
-    relkind "char"
-);
-
-
---
 -- Name: venues; Type: TABLE; Schema: public; Owner: -
 --
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2273,6 +2273,15 @@ CREATE TABLE public.tags (
 
 
 --
+-- Name: tt; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.tt (
+    relkind "char"
+);
+
+
+--
 -- Name: venues; Type: TABLE; Schema: public; Owner: -
 --
 

--- a/lib/tasks/db_missing.rake
+++ b/lib/tasks/db_missing.rake
@@ -3,7 +3,7 @@ namespace :db do
   task :db_missing do
     begin
       Rake::Task['environment'].invoke
-      ActiveRecord::Base.connection
+      ActiveRecord::Base.connection.connect!
     rescue
       exit 1
     else


### PR DESCRIPTION
This was failing to create the db because db_missing was returning with 0 until i added the `connect!` call